### PR TITLE
fix: ゲームマネージャーのバグ修正、フィールドの特殊床がずっと同じ場所に出るの修正

### DIFF
--- a/Assets/Data/SO_StageData_Debug.asset
+++ b/Assets/Data/SO_StageData_Debug.asset
@@ -27,6 +27,6 @@ MonoBehaviour:
     SpawnProbability: 1
     MinSpawnCount: 1
     MaxSpawnCount: 1
-    LifespanTurns: 3
+    LifespanTurns: 1
     SpawnIntervalTurns: 1
   EnemySpecialTileRules: []

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -57,7 +57,7 @@ public class GameManager : MonoBehaviour
         }
         else if (scene.name == "Select")
         {
-            
+
         }
         else if (scene.name == "Game")
         {
@@ -108,7 +108,7 @@ public class GameManager : MonoBehaviour
     {
         // StageNoに応じた読み込みとインスタンス生成
         // Mediatorの初期化
-        _mediator = new GameMadiator();
+        _mediator = new GameMediator();
         _mediator.Initialize();
         // バトルマネージャーの初期化
         _battleManager = new BattleManager();
@@ -132,11 +132,11 @@ public class GameManager : MonoBehaviour
 
     void UpdateGameScene()
     {
-        
+
     }
     void UpdateResultScene()
     {
-        
+
     }
 
 }

--- a/Assets/Scripts/Field/Logic/FieldService.cs
+++ b/Assets/Scripts/Field/Logic/FieldService.cs
@@ -77,6 +77,8 @@ public class FieldService
 
                 cell.CurrentTile = defaultTile; // デフォルト床を配置
 
+                cell.DefaultTile = defaultTile; // デフォルト床の定義も保存
+
                 // デフォルト床が設定されていれば、その通行可否を適用
                 if (defaultTile != null)
                 {


### PR DESCRIPTION
## 概要
バグ修正しました！

## 変更内容
- マネージャーのスペルミス
- フィールドの特殊床のバグ修正

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [●] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [●] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [●] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [●] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [●] **所有権**: データを書き換えているのは「所有システム」のみか
- [●] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [●] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #30 

## その他 (懸念点・共有事項)

