### PR TITLE
feat: ステージデータ一式をまとめて作成できるEditor機能を作成

### DIFF
--- a/Assets/Resources/Data/LevelData/Stage_01.meta
+++ b/Assets/Resources/Data/LevelData/Stage_01.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d31ce2b06d3b13499cd99a58655cc34
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Field.asset
+++ b/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Field.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8b83289a05446744bea2aac39d3c1f6, type: 3}
+  m_Name: Stage_01_Field
+  m_EditorClassIdentifier: Assembly-CSharp::CreatorKousien.Data.StageData
+  _width: 6
+  _height: 3
+  _borderX: 3
+  CellSize: 1
+  BorderGap: 0.5
+  BorderPrefab: {fileID: 0}
+  ObstaclePositions: []
+  _playerStartPosition: {x: 0, y: 0}
+  PlayerDefaultTile: {fileID: 0}
+  EnemyDefaultTile: {fileID: 0}
+  PlayerSpecialTileRules: []
+  EnemySpecialTileRules: []

--- a/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Field.asset.meta
+++ b/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Field.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36ffa9d58076a1148b1921016cb6f8c2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Setup.asset
+++ b/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Setup.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e624d13232efa9c408e8bd1b46d2b728, type: 3}
+  m_Name: Stage_01_Setup
+  m_EditorClassIdentifier: Assembly-CSharp::CreatorKousien.Data.BattleSetupData
+  StageData: {fileID: 11400000, guid: 36ffa9d58076a1148b1921016cb6f8c2, type: 2}
+  PlayerData: {fileID: 0}
+  Enemies: []

--- a/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Setup.asset.meta
+++ b/Assets/Resources/Data/LevelData/Stage_01/Stage_01_Setup.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d76b62dd01db5f4f95ceab8525699fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/StageTemplateGenerator.cs
+++ b/Assets/Scripts/Editor/StageTemplateGenerator.cs
@@ -21,11 +21,27 @@ namespace CreatorKousien.EditorTools
     /// </summary>
     public class StageTemplateGenerator
     {
-        [MenuItem("CreatorKousien/新しいステージセットを作成", priority = 1)]
+        [MenuItem("Assets/Create/CreatorKousien/💯新しいステージセットを作成", false, 10)]
+        [MenuItem("CreatorKousien/💯新しいステージセットを作成", priority = 1)]
         public static void CreateNewStageTemplate()
         {
             // 1. 保存先のベースパス
             string basePath = "Assets/Resources/Data/LevelData";
+
+            if (Selection.activeObject != null)
+            {
+                string selectedPath = AssetDatabase.GetAssetPath(Selection.activeObject);
+
+                // 選択しているのがフォルダの場合はそのフォルダをベースパスにする
+                if (AssetDatabase.IsValidFolder(selectedPath))
+                {
+                    basePath = selectedPath;
+                }
+                else
+                {
+                    basePath = Path.GetDirectoryName(selectedPath).Replace("\\","/");
+                }
+            }
 
             // フォルダが存在しない場合は作成
             if (!Directory.Exists(basePath))


### PR DESCRIPTION
## 概要
Editor機能の追加

## 変更内容
- コンテンツブラウザーからステージセットアップデータを作成できるように
- 上のツールバーからも作成可能

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [●] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [●] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [●] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [●] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [●] **所有権**: データを書き換えているのは「所有システム」のみか
- [●] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [●] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #69 

## その他 (懸念点・共有事項)