### PR TITLE
feat: プレイヤーの攻撃時、現在座標を取得するように修正、敵の基準点に現在座標を追加、敵の衝突を防止

### DIFF
--- a/Assets/Scripts/Battle/Common/ActionRuntimeData.cs
+++ b/Assets/Scripts/Battle/Common/ActionRuntimeData.cs
@@ -28,18 +28,25 @@ namespace CreatorKousien.Battle
         // --- 移動用データ ---
         public GridDirection MoveDirection { get; }
 
+        // 動的計算するかどうか
+        public bool IsDynamicOrigin { get; }
+        // 相対座標
+        public List<Vector2Int> RelativeCells { get; }
+
         /// <summary>
         /// 攻撃用コンストラクタ
         /// </summary>
         /// <param name="actorId"></param>
         /// <param name="attackInfo"></param>
         /// <param name="targetCells"></param>
-        public ActionRuntimeData(int actorId, ActionType type, ActionProperty property, List<Vector2Int> targetCells)
+        public ActionRuntimeData(int actorId, ActionType type, ActionProperty property, List<Vector2Int> targetCells, bool isDynamic = false, List<Vector2Int> relativeCells = null)
         {
             ActorId = actorId;
             Type = type;
             Property = property;
             TargetCells = targetCells;
+            IsDynamicOrigin = isDynamic;
+            RelativeCells = relativeCells ?? new List<Vector2Int>();
         }
 
         /// <summary>

--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -94,7 +94,10 @@ namespace CreatorKousien.Battle
                     _dispatcher.Dispatch(new Command.AttackCommand(
                         nextAction.ActorId,
                         nextAction.Property,
-                        nextAction.TargetCells));
+                        nextAction.TargetCells,
+                        nextAction.IsDynamicOrigin,
+                        nextAction.RelativeCells
+                    ));
                     break;
 
                 // MoveUseCaseへ

--- a/Assets/Scripts/Command/Attack/AttackCommand.cs
+++ b/Assets/Scripts/Command/Attack/AttackCommand.cs
@@ -23,11 +23,16 @@ namespace CreatorKousien.Command
         /// <summary>攻撃が着弾するマスのリスト</summary>
         public List<Vector2Int> TargetCells { get; }
 
-        public AttackCommand(int sourceActorId, ActionProperty property, List<Vector2Int> targetCells)
+        public bool IsDynamicOrigin { get; }
+        public List<Vector2Int> RelativeCells { get; }
+
+        public AttackCommand(int sourceActorId, ActionProperty property, List<Vector2Int> targetCells, bool isDynamic = false, List<Vector2Int> relativeCells = null)
         {
             SourceActorId = sourceActorId;
             Property = property;
             TargetCells = targetCells;
+            IsDynamicOrigin = isDynamic;
+            RelativeCells = relativeCells;
         }
     }
 }

--- a/Assets/Scripts/Enemy/Data/EnemyActionPattern.cs
+++ b/Assets/Scripts/Enemy/Data/EnemyActionPattern.cs
@@ -36,7 +36,8 @@ namespace CreatorKousien.Data
         [Tooltip("盤面の最後列(自陣奥)の中央を基準にする")] BackRowCenter,
         [Tooltip("盤面の左端の中央を基準にする")] LeftEdgeCenter,
         [Tooltip("盤面の右端の中央を基準にする")] RightEdgeCenter,
-        [Tooltip("ランダムな通行可能マスを基準にする")] RandomPassableCell
+        [Tooltip("ランダムな通行可能マスを基準にする")] RandomPassableCell,
+        [Tooltip("自分自身の現在地を動的に基準にする")] SelfPosition,
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Logic/EnemyAI.cs
+++ b/Assets/Scripts/Enemy/Logic/EnemyAI.cs
@@ -74,6 +74,13 @@ namespace CreatorKousien.Enemy
                 // 基準点を元に実際の攻撃範囲を計算
                 List<Vector2Int> rawCells = CalculateTargetCells(pattern, originPos, situation);
 
+                // 自己基準なら、相対座標も計算しておく
+                List<Vector2Int> relativeCells = new List<Vector2Int>();
+                if (pattern.OriginRule == TargetOrigin.SelfPosition)
+                {
+                    relativeCells = CalculateTargetCells(pattern, Vector2Int.zero, situation);
+                }
+
                 // 有効なターゲットますが1つも無ければスキップして次の行動を考える
                 if (rawCells.Count > 0)
                 {
@@ -86,7 +93,9 @@ namespace CreatorKousien.Enemy
                             pattern.Property,
                             rawCells,
                             pattern.ChargeTurns,
-                            pattern.IsInterruptible
+                            pattern.IsInterruptible,
+                            pattern,
+                            relativeCells
                         );
                     })));
                 }

--- a/Assets/Scripts/Enemy/RuntimeData/EnemyIntent.cs
+++ b/Assets/Scripts/Enemy/RuntimeData/EnemyIntent.cs
@@ -22,12 +22,14 @@ namespace CreatorKousien.Enemy
         public ActionType Type;
         public ActionProperty Property;
         public List<Vector2Int> RawTargetCells;
+        public List<Vector2Int> RelativeCells;
         public Vector2Int MoveDirection;
         public int ChargeTurns;
         public bool IsInterruptible;
+        public EnemyActionPattern SourcePattern;
 
         // 静的ファクトリ：攻撃
-        public static EnemyIntent CreateAttack(int id, ActionType type, ActionProperty property, List<Vector2Int> cells, int charge, bool interrupt)
+        public static EnemyIntent CreateAttack(int id, ActionType type, ActionProperty property, List<Vector2Int> cells, int charge, bool interrupt, EnemyActionPattern pattern = null, List<Vector2Int> relativeCells = null)
         {
             return new EnemyIntent
             {
@@ -36,7 +38,9 @@ namespace CreatorKousien.Enemy
                 Property = property,
                 RawTargetCells = cells,
                 ChargeTurns = charge,
-                IsInterruptible = interrupt
+                IsInterruptible = interrupt,
+                SourcePattern = pattern,
+                RelativeCells = relativeCells ?? new List<Vector2Int>()
             };
         }
 

--- a/Assets/Scripts/UseCase/Attack/AttackUseCase.cs
+++ b/Assets/Scripts/UseCase/Attack/AttackUseCase.cs
@@ -56,19 +56,34 @@ namespace CreatorKousien.UseCase
             // ログ用: 誰の行動かを色分け
             string actorLabel = GetActorLabel(command.SourceActorId);
 
-            // ゴーストアクション防止
+            // 生存確認
             Vector2Int currentPos = _fieldService.GetActorPosition(command.SourceActorId);
             if (currentPos.x == -1)
             {
+                Debug.Log($"<color=gray>[ATTACK SKIP] {actorLabel} は既に倒れているためスキップ</color>");
                 _eventBus.PublishActionLogicCompleted(command.SourceActorId);
                 return;
             }
 
+            // 実行の瞬間に、最終的な攻撃マスを決定する
+            List<Vector2Int> finalTargetCells = command.TargetCells;
+
+            if (command.IsDynamicOrigin)
+            {
+                finalTargetCells = new List<Vector2Int>();
+                // 現在地 + 予約していた相対座標
+                foreach (var relPos in command.RelativeCells)
+                {
+                    finalTargetCells.Add(currentPos + relPos);
+                }
+                Debug.Log($"[DynamicAttack] {actorLabel} が現在地 {currentPos} を基準に攻撃！");
+            }
+
             // 攻撃が発動した瞬間に対象のマスをEventBusで通知 (4/19 追加)
-            _eventBus.OnAttackAreaExecuted?.Invoke(command.TargetCells);
+            _eventBus.OnAttackAreaExecuted?.Invoke(finalTargetCells);
 
             // 1. FieldServiceにマスにいるActorIDのリストをもらう
-            List<int> targetActorIds = _fieldService.GetActorsInCells(command.TargetCells);
+            List<int> targetActorIds = _fieldService.GetActorsInCells(finalTargetCells);
 
             // 2. もし誰もいなければ、空振りエフェクトを出して終了
             if (targetActorIds.Count == 0)

--- a/Assets/Scripts/UseCase/Enemy/EnemyActionUseCase.cs
+++ b/Assets/Scripts/UseCase/Enemy/EnemyActionUseCase.cs
@@ -93,20 +93,83 @@ namespace CreatorKousien.UseCase
                 // 現在の仮想座標を取得
                 Vector2Int currentVirtualPos = virtualPositions[actingEnemyId];
 
-                // 指名されたエネミーに思考させる
+                // 1. 指名されたエネミーに思考させる
                 EnemyIntent intent = ai.Think(situation, virtualPositions[actingEnemyId]);
-                var actionTicket = ConvertIntentToTicket(intent, step, currentVirtualPos);
 
-                plan.Add(actionTicket);
-
-                // 移動した場合は、そのエネミーの仮想座標だけを更新
+                // 2. 移動の場合は衝突チェックと代替ルートの検索を行う
                 if (intent.Type == ActionType.Move)
                 {
-                    virtualPositions[actingEnemyId] += intent.MoveDirection;
+                    Vector2Int targetPos = currentVirtualPos + intent.MoveDirection;
+
+                    if (!IsValidMove(targetPos, actingEnemyId, virtualPositions))
+                    {
+                        // ダメだった場合、4方向をランダムな順番で試す
+                        Vector2Int[] dirs = { Vector2Int.up, Vector2Int.down, Vector2Int.left, Vector2Int.right };
+                        ShuffleArray(dirs);
+
+                        bool foundRoute = false;
+                        foreach (var dir in dirs)
+                        {
+                            Vector2Int alternativePos = currentVirtualPos + dir;
+                            if (IsValidMove(alternativePos, actingEnemyId, virtualPositions))
+                            {
+                                intent.MoveDirection = dir;
+                                foundRoute = true;
+                                break;
+                            }
+                        }
+
+                        // もし4方向すべて壁や味方に囲まれていたら待機
+                        if (!foundRoute)
+                        {
+                            intent.Type = ActionType.Wait;
+                        }
+                    }
                 }
+
+                // 3. 確定した意図をチケットに変換
+                var actionTicket = ConvertIntentToTicket(intent, step, currentVirtualPos, virtualPositions);
+                plan.Add(actionTicket);
             }
 
             return plan;
+        }
+
+        /// <summary>
+        /// 移動先が安全課を判定する
+        /// </summary>
+        /// <param name="targetPos"></param>
+        /// <param name="actorId"></param>
+        /// <param name="virtualPositions"></param>
+        /// <returns></returns>
+        private bool IsValidMove(Vector2Int targetPos, int actorId, Dictionary<int, Vector2Int> virtualPositions)
+        {
+            if (_fieldService.IsOutOfBounds(targetPos.x, targetPos.y)) return false;
+            if (_fieldService.IsObstacle(targetPos.x, targetPos.y)) return false;
+            if (targetPos.x < _fieldService.GetBorderX()) return false;
+
+            // 仮想空間の他の敵と重ならないかチェック
+            foreach (var kvp in virtualPositions)
+            {
+                if (kvp.Key != actorId && kvp.Value == targetPos) return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 配列をランダムに並び替える
+        /// </summary>
+        /// <param name="array"></param>
+        private void ShuffleArray(Vector2Int[] array)
+        {
+            for (int i = 0; i < array.Length; i++)
+            {
+                Vector2Int temp = array[i];
+                int randomIndex = Random.Range(i, array.Length);
+                array[i] = array[randomIndex];
+                array[randomIndex] = temp;
+            }
         }
 
         private BattleSituation CreateSituation()
@@ -121,13 +184,16 @@ namespace CreatorKousien.UseCase
             };
         }
 
-        private ActionRuntimeData ConvertIntentToTicket(EnemyIntent intent, int step, Vector2Int currentVirtualPos)
+        private ActionRuntimeData ConvertIntentToTicket(EnemyIntent intent, int step, Vector2Int currentVirtualPos, Dictionary<int, Vector2Int> virtualPositions)
         {
             switch (intent.Type)
             {
                 case ActionType.FastAttack:
                 case ActionType.WideAttack:
                     // UseCase側でクリッピング（場外・障害物判定）を行う
+                    bool isDynamic = (intent.SourcePattern != null && intent.SourcePattern.OriginRule == TargetOrigin.SelfPosition);
+                    List<Vector2Int> relativeCells = intent.RelativeCells;
+
                     var validCells = intent.RawTargetCells.FindAll(p =>
                         !_fieldService.IsOutOfBounds(p.x, p.y) && !_fieldService.IsObstacle(p.x, p.y));
 
@@ -136,29 +202,20 @@ namespace CreatorKousien.UseCase
                     // Viewに攻撃予告の色変更を指示
                     _eventBus.PublishTelegraph(validCells, true, step);
 
-                    return new ActionRuntimeData(intent.SourceActorId, intent.Type, intent.Property, validCells);
+                    return new ActionRuntimeData(intent.SourceActorId, intent.Type, intent.Property, validCells, isDynamic, relativeCells);
 
                 case ActionType.Move:
                     GridDirection dir = ConvertToGridDirection(intent.MoveDirection);
 
                     Vector2Int targetPos = currentVirtualPos + intent.MoveDirection;
-                    
-                    // 盤面内かどうかに加え、敵陣内（x が BorderX 以上）かどうかもチェック
-                    int borderX = _fieldService.GetBorderX();
-                    bool isValidMove = !_fieldService.IsOutOfBounds(targetPos.x, targetPos.y)
-                                    && !_fieldService.IsObstacle(targetPos.x, targetPos.y)
-                                    && targetPos.x >= borderX;
 
-                    // Viewに移動予告のSphere表示を指示
-                    if (isValidMove)
-                    {
-                        _eventBus.PublishMoveTelegraph(targetPos, true, step);
-                    }
-                    else
-                    {
-                        // 無効ならその場に止まる
-                    }
+                    // 予告をViewに出す
+                    _eventBus.PublishMoveTelegraph(targetPos, true, step);
 
+                    // 仮想座標を更新する
+                    virtualPositions[intent.SourceActorId] = targetPos;
+
+                    // そのままチケットとして提出
                     return new ActionRuntimeData(intent.SourceActorId, dir);
 
                 case ActionType.Guard:

--- a/Assets/Scripts/UseCase/Player/PlayerActionUseCase.cs
+++ b/Assets/Scripts/UseCase/Player/PlayerActionUseCase.cs
@@ -13,7 +13,6 @@ using CreatorKousien.Player;
 using CreatorKousien.Field;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor.Build.Pipeline.Tasks;
 
 namespace CreatorKousien.UseCase
 {
@@ -55,11 +54,11 @@ namespace CreatorKousien.UseCase
             }
             else
             {
-                // 攻撃等の場合は、プレイヤーの現在地を基準にターゲットマスを計算
-                Vector2Int playerPos = _playerSystem.RuntimeData.Position;
-                List<Vector2Int> targetCells = CalculateTargetCells(playerPos, effect.AreaType);
+                // 自分中心の相対座標を取得
+                List<Vector2Int> relativeCells = CalculateRelativeCells(effect.AreaType);
 
-                actionData = new ActionRuntimeData(playerId, effect.Type, effect.Property, targetCells);
+                // TargetCellsには一旦空を渡し、動的フラグと相対座標をセットする
+                actionData = new ActionRuntimeData(playerId, effect.Type, effect.Property, new List<Vector2Int>(), true, relativeCells);
             }
 
             // 3. TurnManagerにアクションを提出
@@ -83,28 +82,33 @@ namespace CreatorKousien.UseCase
             }
         }
 
-
-        private List<Vector2Int> CalculateTargetCells(Vector2Int origin, TargetAreaType areaType)
+        /// <summary>
+        /// 原点を(0,0)とした相対座標を返す
+        /// </summary>
+        /// <param name="areaType"></param>
+        /// <returns></returns>
+        private List<Vector2Int> CalculateRelativeCells(TargetAreaType areaType)
         {
             var cells = new List<Vector2Int>();
 
             switch (areaType)
             {
                 case TargetAreaType.Front1:
-                    cells.Add(origin + new Vector2Int(1, 0));
+                    cells.Add(new Vector2Int(1, 0));
                     break;
+
                 case TargetAreaType.FrontPierce2:
-                    cells.Add(origin + new Vector2Int(1, 0));
-                    cells.Add(origin + new Vector2Int(2, 0));
+                    cells.Add(new Vector2Int(1, 0));
+                    cells.Add(new Vector2Int(2, 0));
                     break;
+
                 case TargetAreaType.Surround:
-                    cells.Add(origin + new Vector2Int(1, 0));
-                    cells.Add(origin + new Vector2Int(-1, 0));
-                    cells.Add(origin + new Vector2Int(0, 1));
-                    cells.Add(origin + new Vector2Int(0, -1));
+                    cells.Add(new Vector2Int(1, 0)); cells.Add(new Vector2Int(-1, 0));
+                    cells.Add(new Vector2Int(0, 1)); cells.Add(new Vector2Int(0, -1));
                     break;
+
                 case TargetAreaType.Self:
-                    cells.Add(origin);
+                    cells.Add(Vector2Int.zero);
                     break;
             }
 


### PR DESCRIPTION
## 概要
色々修正した！

## 変更内容
- プレイヤーの攻撃時に現在座標を取得するように修正
- 敵の基準点に敵の現在座標を追加
- 敵同士、場外への衝突を防止
- 

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [x] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #135

## その他 (懸念点・共有事項)
*特になければ削除してください。*
