### PR TITLE
fix: コマンドフェーズ外でも入力が取れてしまうのを修正しました。

### DIFF
--- a/Assets/Scripts/Battle/Turn/States/CommandPhaseState.cs
+++ b/Assets/Scripts/Battle/Turn/States/CommandPhaseState.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using CreatorKousien.Command;
 using CreatorKousien.Data;
+using UnityEngine.InputSystem;
 
 namespace CreatorKousien.Battle
 {
@@ -50,7 +51,7 @@ namespace CreatorKousien.Battle
             _enemyPlannedActions.Clear();
 
             // タイマーの初期化
-            _currentTime = _timeLimit;
+            _currentTime = _owner.CommandTimeLimit;
             _isTimeUp = false;
 
             _owner.EventBus.PublishCommandPhaseStarted();
@@ -89,6 +90,8 @@ namespace CreatorKousien.Battle
         public void Update()
         {
             // 時間ゲージのカウントダウンロジック、カード選択等
+            // タイムアップしているか、3手入力済みなら何もしない
+            if (_isTimeUp || _playerSelectedActions.Count >= _owner.MaxInputCount) return;
 
             // 既にタイムアップしているか、3手入力済みなら何もしない
             if (_isTimeUp || _playerSelectedActions.Count >= 3) return;
@@ -112,7 +115,43 @@ namespace CreatorKousien.Battle
                 FillRemainingActionsWithWait();
                 FinishPhase();
             }
+
+            HandleInput();
         }
+
+
+        /// <summary>
+        /// プレイヤーの入力を処理するメソッド。キーボードとゲームパッドの両方に対応しています。
+        /// </summary>
+        private void HandleInput()
+        {
+            // キーボードとゲームパッドの両方に対応した入力処理
+            var kb = Keyboard.current;
+            var pad = Gamepad.current;
+
+            bool pressUp = (kb != null && (kb.upArrowKey.wasPressedThisFrame || kb.wKey.wasPressedThisFrame)) ||
+                           (pad != null && (pad.dpad.up.wasPressedThisFrame || pad.buttonNorth.wasPressedThisFrame));
+            bool pressDown = (kb != null && (kb.downArrowKey.wasPressedThisFrame || kb.sKey.wasPressedThisFrame)) ||
+                             (pad != null && (pad.dpad.down.wasPressedThisFrame || pad.buttonSouth.wasPressedThisFrame));
+            bool pressLeft = (kb != null && (kb.leftArrowKey.wasPressedThisFrame || kb.aKey.wasPressedThisFrame)) ||
+                             (pad != null && (pad.dpad.left.wasPressedThisFrame || pad.buttonWest.wasPressedThisFrame));
+            bool pressRight = (kb != null && (kb.rightArrowKey.wasPressedThisFrame || kb.dKey.wasPressedThisFrame)) ||
+                              (pad != null && (pad.dpad.right.wasPressedThisFrame || pad.buttonEast.wasPressedThisFrame));
+
+            if (pressUp) _owner.Dispatcher.Dispatch(new PlayerActionCommand(SlotPosition.Up));
+            if (pressDown) _owner.Dispatcher.Dispatch(new PlayerActionCommand(SlotPosition.Down));
+            if (pressLeft) _owner.Dispatcher.Dispatch(new PlayerActionCommand(SlotPosition.Left));
+            if (pressRight) _owner.Dispatcher.Dispatch(new PlayerActionCommand(SlotPosition.Right));
+
+            if ((kb != null && kb.spaceKey.wasPressedThisFrame) || (pad != null && pad.rightShoulder.wasPressedThisFrame))
+            {
+                // 決定ボタンでフェーズを強制終了
+                Debug.Log("<color=yellow>[Command Phase] プレイヤーが決定ボタンを押しました。フェーズを終了します。</color>");
+                FillRemainingActionsWithWait();
+                FinishPhase();
+            }
+        }
+
 
         /// <summary>
         /// 時間切れ、またはプレイヤーの決定ボタンで呼ばれる
@@ -134,7 +173,7 @@ namespace CreatorKousien.Battle
             Debug.Log($"[Command] プレイヤーのアクションを予約: {action.Type} ({_playerSelectedActions.Count}/3)");
 
             // 3手選んだら自動で実行フェーズへ
-            if (_playerSelectedActions.Count == 3)
+            if (_playerSelectedActions.Count == _owner.MaxInputCount)
             {
                 FinishPhase();
             }
@@ -152,7 +191,7 @@ namespace CreatorKousien.Battle
         // 足りない手数を待機で埋めるメソッド
         private void FillRemainingActionsWithWait()
         {
-            while (_playerSelectedActions.Count < 3)
+            while (_playerSelectedActions.Count < _owner.MaxInputCount)
             {
                 var waitAction = new ActionRuntimeData(
                     1,
@@ -173,7 +212,7 @@ namespace CreatorKousien.Battle
         private List<ActionRuntimeData> InterleaveActions(List<ActionRuntimeData> pActions, List<ActionRuntimeData> eActions)
         {
             List<ActionRuntimeData> result = new List<ActionRuntimeData>();
-            int maxSteps = 3;
+            int maxSteps = _owner.MaxInputCount;
 
             for (int i = 0; i < maxSteps; i++)
             {
@@ -191,10 +230,10 @@ namespace CreatorKousien.Battle
         /// <param name="action"></param>
         public void AddEnemyAction(ActionRuntimeData action)
         {
-            if (_enemyPlannedActions.Count >= 3) return;
+            if (_enemyPlannedActions.Count >= _owner.MaxInputCount) return;
 
             _enemyPlannedActions.Add(action);
-            Debug.Log($"[Command] 敵のアクションを予約: {action.Type} ({_enemyPlannedActions.Count}/3)");
+            Debug.Log($"[Command] 敵のアクションを予約: {action.Type} ({_enemyPlannedActions.Count}/{_owner.MaxInputCount})");
         }
     }
 }

--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -15,6 +15,27 @@ namespace CreatorKousien.Battle
 {
     public class TurnManager : MonoBehaviour
     {
+        [Header("コマンドフェーズの設定")]
+        [SerializeField] private int _maxInputCount = 3;        // プレイヤーがコマンドフェーズで入力できる最大アクション数
+        [SerializeField] private float _commandTimeLimit = 3f;  // コマンドフェーズの時間制限（秒）
+
+        /// <summary>
+        /// 最大入力数
+        /// </summary>
+        public int MaxInputCount => _maxInputCount;
+
+        /// <summary>
+        /// コマンドフェーズの時間制限
+        /// </summary>
+        public float CommandTimeLimit => _commandTimeLimit;
+
+
+        /// <summary>
+        /// プレイヤーがカードを使ったことを通知するイベント
+        /// </summary>
+        public event System.Action OnPlayerActionSubmitted;
+
+
         private PhaseManager _phaseManager;
         private CommandDispatcher _dispatcher;
         private GameEventBus _eventBus;
@@ -142,6 +163,9 @@ namespace CreatorKousien.Battle
             if (_phaseManager.CurrentPhaseType == PhaseType.Command)
             {
                 _commandPhase.AddPlayerAction(action);
+
+                // プレイヤーのアクションが提出されたことを通知
+                OnPlayerActionSubmitted?.Invoke();
             }
         }
 

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -276,6 +276,8 @@ public class GameManager : MonoBehaviour
         // ------------------------------------------------------------
         _turnManager.Initialize(_dispatcher, _eventBus, _handState);
 
+        _turnManager.OnPlayerActionSubmitted += UpdateCardUI; // プレイヤーが行動を提出したらカードUIを更新する
+
 
         // 10. Mediator初期化
         // ------------------------------------------------------------
@@ -304,33 +306,6 @@ public class GameManager : MonoBehaviour
 
     void UpdateGameScene()
     {
-        if (_mediator == null || _player == null) return;
-
-        var kb = UnityEngine.InputSystem.Keyboard.current;
-        var pad = UnityEngine.InputSystem.Gamepad.current;
-
-        // 複合入力チェック！ (WASD or 十字キー or パッドボタン/十字)
-        bool pressUp = (kb != null && (kb.upArrowKey.wasPressedThisFrame || kb.wKey.wasPressedThisFrame)) ||
-                       (pad != null && (pad.dpad.up.wasPressedThisFrame || pad.buttonNorth.wasPressedThisFrame));
-
-        bool pressDown = (kb != null && (kb.downArrowKey.wasPressedThisFrame || kb.sKey.wasPressedThisFrame)) ||
-                         (pad != null && (pad.dpad.down.wasPressedThisFrame || pad.buttonSouth.wasPressedThisFrame));
-
-        bool pressLeft = (kb != null && (kb.leftArrowKey.wasPressedThisFrame || kb.aKey.wasPressedThisFrame)) ||
-                         (pad != null && (pad.dpad.left.wasPressedThisFrame || pad.buttonWest.wasPressedThisFrame));
-
-        bool pressRight = (kb != null && (kb.rightArrowKey.wasPressedThisFrame || kb.dKey.wasPressedThisFrame)) ||
-                          (pad != null && (pad.dpad.right.wasPressedThisFrame || pad.buttonEast.wasPressedThisFrame));
-
-        // カード入力とUI更新
-        bool cardUsed = false;
-        if (pressUp) { _mediator.SendCommand(new PlayerActionCommand(SlotPosition.Up)); cardUsed = true; }
-        if (pressDown) { _mediator.SendCommand(new PlayerActionCommand(SlotPosition.Down)); cardUsed = true; }
-        if (pressLeft) { _mediator.SendCommand(new PlayerActionCommand(SlotPosition.Left)); cardUsed = true; }
-        if (pressRight) { _mediator.SendCommand(new PlayerActionCommand(SlotPosition.Right)); cardUsed = true; }
-
-        // カードを使ったら、即座にUIを更新して表裏の絵を切り替える！
-        if (cardUsed) UpdateCardUI();
     }
 
     void UpdateResultScene()


### PR DESCRIPTION
## 概要
三手打ち切ったら実行フェーズに遷移。手数や時間はInspectorでいじることができます。

## 変更内容
- TurnMangaer
- GameMangerの修正

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [x] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #146 

## その他 (懸念点・共有事項)
