### PR TITLE
chore: GitHub Project automation and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_task.yml
+++ b/.github/ISSUE_TEMPLATE/01_task.yml
@@ -1,0 +1,78 @@
+name: "\U0001F4DD Task"
+description: 実装・調査・調整などの一般タスク
+title: "[TASK] "
+labels: ["task"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: この Issue で完了させたい内容を記載してください。
+      placeholder: 例: プレイヤー移動時の床効果発火処理を実装する
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景・目的
+      description: この作業が必要な理由や前提を記載してください。
+      placeholder: 例: バトル開始前の盤面ギミック検証に必要
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 完了条件
+      description: 完了とみなす条件を箇条書きで記載してください。
+      placeholder: |
+        - [ ] 床効果が 1 回だけ発火する
+        - [ ] 既存の移動演出を壊さない
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度
+      description: GitHub Project の Priority フィールドに同期されます。
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+        - P4
+        - P5
+        - P6
+        - P7
+        - P8
+        - P9
+    validations:
+      required: true
+
+  - type: input
+    id: start_date
+    attributes:
+      label: Start date
+      description: GitHub Project の Start date フィールドに同期されます。
+      placeholder: YYYY-MM-DD
+    validations:
+      required: false
+
+  - type: input
+    id: target_date
+    attributes:
+      label: Target date
+      description: GitHub Project の Target date フィールドに同期されます。
+      placeholder: YYYY-MM-DD
+    validations:
+      required: false
+
+  - type: input
+    id: ref_url
+    attributes:
+      label: 参考 URL
+      placeholder: https://github.com/...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug.yml
@@ -1,0 +1,85 @@
+name: "\U0001F41B Bug"
+description: 不具合報告
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 事象概要
+      description: 何が起きているか、期待値と合わせて記載してください。
+      placeholder: 例: 手札を 0 枚にした直後、ターン終了で例外が発生する
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する挙動
+      placeholder: 例: 手札が 0 枚でもターン終了処理が継続する
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      placeholder: |
+        1. チュートリアル戦闘を開始する
+        2. 手札をすべて使用する
+        3. ターン終了ボタンを押す
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: 環境
+      placeholder: Windows 11 / Unity 6000.3.7f1 / Editor
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度
+      description: GitHub Project の Priority フィールドに同期されます。
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+        - P4
+        - P5
+        - P6
+        - P7
+        - P8
+        - P9
+    validations:
+      required: true
+
+  - type: input
+    id: start_date
+    attributes:
+      label: Start date
+      description: GitHub Project の Start date フィールドに同期されます。
+      placeholder: YYYY-MM-DD
+    validations:
+      required: false
+
+  - type: input
+    id: target_date
+    attributes:
+      label: Target date
+      description: GitHub Project の Target date フィールドに同期されます。
+      placeholder: YYYY-MM-DD
+    validations:
+      required: false
+
+  - type: input
+    id: ref_url
+    attributes:
+      label: 参考 URL
+      placeholder: https://github.com/...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "\U0001F4D8 開発ドキュメント"
+    url: https://github.com/aptmara/CreatorKousien/tree/master/docs
+    about: 設計資料や命名規約を確認してから Issue を作成してください。

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,250 @@
+name: Auto Add Issue to Project
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token
+        id: check-token
+        run: |
+          if [ -n "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "token_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "token_exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::PROJECT_TOKEN is not set. Skipping project automation."
+          fi
+
+      - name: Checkout repository
+        if: steps.check-token.outputs.token_exists == 'true'
+        uses: actions/checkout@v4
+
+      - name: Add to Project
+        if: steps.check-token.outputs.token_exists == 'true' && github.event.action != 'edited'
+        id: add-project
+        uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/users/aptmara/projects/4
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+
+      - name: Extract Issue Fields
+        if: steps.check-token.outputs.token_exists == 'true'
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const raw = context.payload.issue.body || '';
+            const lines = raw.replace(/\r\n/g, '\n').split('\n');
+
+            const aliases = {
+              priority: ['優先度', 'priority'],
+              startDate: ['start date', '開始日', 'start_date'],
+              targetDate: ['target date', '期日', 'end date', 'due date', 'target_date'],
+            };
+
+            function normalizeLine(value) {
+              return (value || '').trim().toLowerCase().replace(/^#+\s*/, '');
+            }
+
+            function pickValue(keys) {
+              for (let i = 0; i < lines.length; i += 1) {
+                const line = normalizeLine(lines[i]);
+                const matched = keys.some((key) => line.startsWith(key));
+                if (!matched) {
+                  continue;
+                }
+
+                let cursor = i + 1;
+                while (cursor < lines.length && lines[cursor].trim().length === 0) {
+                  cursor += 1;
+                }
+
+                if (cursor < lines.length) {
+                  return lines[cursor].trim();
+                }
+
+                return '';
+              }
+
+              return '';
+            }
+
+            const priority = pickValue(aliases.priority);
+            const startDate = pickValue(aliases.startDate);
+            const targetDate = pickValue(aliases.targetDate);
+            const status = ['opened', 'reopened'].includes(context.payload.action) ? 'Ready' : '';
+            core.setOutput('priority', priority);
+            core.setOutput('start_date', startDate);
+            core.setOutput('target_date', targetDate);
+            core.setOutput('status', status);
+
+      - name: Get Project Data
+        if: steps.check-token.outputs.token_exists == 'true'
+        uses: actions/github-script@v7
+        id: project-data
+        env:
+          ITEM_ID_HINT: ${{ steps.add-project.outputs.itemId }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const user = 'aptmara';
+            const projectNumber = 4;
+            const itemIdHint = process.env.ITEM_ID_HINT;
+
+            const projectQuery = `
+              query($login: String!, $number: Int!) {
+                user(login: $login) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2Field { id name dataType }
+                        ... on ProjectV2SingleSelectField { id name dataType options { id name } }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const itemQuery = `
+              query($login: String!, $number: Int!, $first: Int!, $after: String) {
+                user(login: $login) {
+                  projectV2(number: $number) {
+                    items(first: $first, after: $after) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue { id number }
+                        }
+                      }
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const addMutation = `
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                  item {
+                    id
+                  }
+                }
+              }
+            `;
+
+            async function findItemId() {
+              let after = null;
+
+              while (true) {
+                const response = await github.graphql(itemQuery, {
+                  login: user,
+                  number: projectNumber,
+                  first: 100,
+                  after,
+                });
+
+                const items = response.user.projectV2.items;
+                const hit = items.nodes.find((node) => node.content && node.content.number === issue.number);
+                if (hit) {
+                  return hit.id;
+                }
+
+                if (!items.pageInfo.hasNextPage) {
+                  return null;
+                }
+
+                after = items.pageInfo.endCursor;
+              }
+            }
+
+            const projectResponse = await github.graphql(projectQuery, {
+              login: user,
+              number: projectNumber,
+            });
+
+            const project = projectResponse.user.projectV2;
+            if (!project) {
+              core.setFailed(`Project ${projectNumber} was not found for user ${user}.`);
+              return;
+            }
+
+            let itemId = itemIdHint || null;
+            if (!itemId) {
+              itemId = await findItemId();
+            }
+
+            if (!itemId) {
+              try {
+                const addResponse = await github.graphql(addMutation, {
+                  projectId: project.id,
+                  contentId: issue.node_id,
+                });
+                itemId = addResponse.addProjectV2ItemById.item.id;
+              } catch (error) {
+                console.log(`Add item fallback failed: ${error.message}`);
+                itemId = await findItemId();
+              }
+            }
+
+            if (!itemId) {
+              core.setFailed('Project item could not be resolved.');
+              return;
+            }
+
+            const fields = {};
+            const fieldOptions = {};
+            for (const field of project.fields.nodes) {
+              fields[field.name] = field.id;
+              if (field.options) {
+                const options = {};
+                for (const option of field.options) {
+                  options[option.name] = option.id;
+                }
+                fieldOptions[field.name] = options;
+              }
+            }
+
+            core.setOutput('project_id', project.id);
+            core.setOutput('item_id', itemId);
+            core.setOutput('fields', JSON.stringify(fields));
+            core.setOutput('field_options', JSON.stringify(fieldOptions));
+
+      - name: Set Project Fields
+        if: steps.check-token.outputs.token_exists == 'true' && steps.project-data.outputs.project_id != ''
+        uses: actions/github-script@v7
+        env:
+          PROJECT_ID: ${{ steps.project-data.outputs.project_id }}
+          ITEM_ID: ${{ steps.project-data.outputs.item_id }}
+          FIELDS: ${{ steps.project-data.outputs.fields }}
+          FIELD_OPTIONS: ${{ steps.project-data.outputs.field_options }}
+          PRIORITY: ${{ steps.extract.outputs.priority }}
+          START_DATE: ${{ steps.extract.outputs.start_date }}
+          TARGET_DATE: ${{ steps.extract.outputs.target_date }}
+          STATUS: ${{ steps.extract.outputs.status }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const path = require('path');
+            const fs = require('fs');
+            const scriptPath = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/scripts/set-project-fields.js');
+            if (!fs.existsSync(scriptPath)) {
+              core.setFailed(`Script not found: ${scriptPath}`);
+              return;
+            }
+
+            const run = require(scriptPath);
+            await run({ core, github, process });

--- a/.github/workflows/close-to-done.yml
+++ b/.github/workflows/close-to-done.yml
@@ -1,0 +1,160 @@
+name: Auto Update Status to Done
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  update-status:
+    name: Update project status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token
+        id: check-token
+        run: |
+          if [ -n "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "token_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "token_exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::PROJECT_TOKEN is not set. Skipping project automation."
+          fi
+
+      - name: Checkout repository
+        if: steps.check-token.outputs.token_exists == 'true'
+        uses: actions/checkout@v4
+
+      - name: Get Project Data
+        if: steps.check-token.outputs.token_exists == 'true'
+        uses: actions/github-script@v7
+        id: project-data
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const user = 'aptmara';
+            const projectNumber = 4;
+
+            const projectQuery = `
+              query($login: String!, $number: Int!) {
+                user(login: $login) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2Field { id name dataType }
+                        ... on ProjectV2SingleSelectField { id name dataType options { id name } }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const itemQuery = `
+              query($login: String!, $number: Int!, $first: Int!, $after: String) {
+                user(login: $login) {
+                  projectV2(number: $number) {
+                    items(first: $first, after: $after) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue { id number }
+                        }
+                      }
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            async function findItemId() {
+              let after = null;
+
+              while (true) {
+                const response = await github.graphql(itemQuery, {
+                  login: user,
+                  number: projectNumber,
+                  first: 100,
+                  after,
+                });
+
+                const items = response.user.projectV2.items;
+                const hit = items.nodes.find((node) => node.content && node.content.number === issue.number);
+                if (hit) {
+                  return hit.id;
+                }
+
+                if (!items.pageInfo.hasNextPage) {
+                  return null;
+                }
+
+                after = items.pageInfo.endCursor;
+              }
+            }
+
+            const projectResponse = await github.graphql(projectQuery, {
+              login: user,
+              number: projectNumber,
+            });
+
+            const project = projectResponse.user.projectV2;
+            if (!project) {
+              core.setFailed(`Project ${projectNumber} was not found for user ${user}.`);
+              return;
+            }
+
+            const fields = {};
+            const fieldOptions = {};
+            for (const field of project.fields.nodes) {
+              fields[field.name] = field.id;
+              if (field.options) {
+                const options = {};
+                for (const option of field.options) {
+                  options[option.name] = option.id;
+                }
+                fieldOptions[field.name] = options;
+              }
+            }
+
+            const itemId = await findItemId();
+            if (!itemId) {
+              console.log('Project item for this issue was not found. Skip status update.');
+              core.setOutput('project_id', project.id);
+              core.setOutput('item_id', '');
+              core.setOutput('fields', JSON.stringify(fields));
+              core.setOutput('field_options', JSON.stringify(fieldOptions));
+              return;
+            }
+
+            core.setOutput('project_id', project.id);
+            core.setOutput('item_id', itemId);
+            core.setOutput('fields', JSON.stringify(fields));
+            core.setOutput('field_options', JSON.stringify(fieldOptions));
+
+      - name: Set Status to Done
+        if: steps.check-token.outputs.token_exists == 'true' && steps.project-data.outputs.project_id != '' && steps.project-data.outputs.item_id != ''
+        uses: actions/github-script@v7
+        env:
+          PROJECT_ID: ${{ steps.project-data.outputs.project_id }}
+          ITEM_ID: ${{ steps.project-data.outputs.item_id }}
+          FIELDS: ${{ steps.project-data.outputs.fields }}
+          FIELD_OPTIONS: ${{ steps.project-data.outputs.field_options }}
+          STATUS: Done
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const path = require('path');
+            const fs = require('fs');
+            const scriptPath = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/scripts/set-project-fields.js');
+            if (!fs.existsSync(scriptPath)) {
+              core.setFailed(`Script not found: ${scriptPath}`);
+              return;
+            }
+
+            const run = require(scriptPath);
+            await run({ core, github, process });

--- a/.github/workflows/scripts/set-project-fields.js
+++ b/.github/workflows/scripts/set-project-fields.js
@@ -1,0 +1,225 @@
+/**
+ * @file GitHub Project の single select フィールドを更新する補助スクリプト
+ * @author 山内陽
+ */
+/**
+ * @param {string} name JSON 名
+ * @param {string} raw 生 JSON
+ * @param {{ setFailed(message: string): void }} core GitHub Actions Core
+ * @returns {Record<string, unknown> | null}
+ */
+function safeParse(name, raw, core) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    core.setFailed(`${name} の JSON 解析に失敗しました: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * @param {string} value 正規化対象
+ * @returns {string}
+ */
+function normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+/**
+ * @param {string} rawValue 入力値
+ * @returns {string}
+ */
+function mapPriority(rawValue) {
+  const value = String(rawValue || '').trim().toUpperCase();
+  if (/^P\d+$/.test(value)) {
+    return value;
+  }
+
+  if (/^\d+$/.test(value)) {
+    return `P${value}`;
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} rawValue 入力値
+ * @returns {string}
+ */
+function mapDate(rawValue) {
+  return String(rawValue || '').trim();
+}
+
+/**
+ * @param {Record<string, string>} fields フィールド ID 一覧
+ * @param {Record<string, Record<string, string>>} fieldOptions Option 一覧
+ * @returns {{ fieldIdByName: Map<string, string>, optionIdByFieldName: Map<string, Map<string, string>> }}
+ */
+function buildFieldMaps(fields, fieldOptions) {
+  return {
+    fieldIdByName: new Map(
+      Object.entries(fields).map(([name, id]) => [normalize(name), id]),
+    ),
+    optionIdByFieldName: new Map(
+      Object.entries(fieldOptions).map(([fieldName, options]) => [
+        normalize(fieldName),
+        new Map(
+          Object.entries(options || {}).map(([optionName, optionId]) => [
+            normalize(optionName),
+            optionId,
+          ]),
+        ),
+      ]),
+    ),
+  };
+}
+
+async function run({ core, github, process }) {
+  if (!process.env.PROJECT_ID || !process.env.ITEM_ID) {
+    core.setFailed('PROJECT_ID または ITEM_ID が不足しています。');
+    return;
+  }
+
+  if (!process.env.FIELDS || !process.env.FIELD_OPTIONS) {
+    core.setFailed('FIELDS または FIELD_OPTIONS が不足しています。');
+    return;
+  }
+
+  const fields = safeParse('FIELDS', process.env.FIELDS, core);
+  const fieldOptions = safeParse('FIELD_OPTIONS', process.env.FIELD_OPTIONS, core);
+  if (!fields || !fieldOptions) {
+    return;
+  }
+
+  const { fieldIdByName, optionIdByFieldName } = buildFieldMaps(fields, fieldOptions);
+
+  /**
+   * @param {string} fieldName フィールド名
+   * @param {string} rawValue 設定値
+   * @returns {Promise<void>}
+   */
+  async function setSingleSelectField(fieldName, rawValue) {
+    const fieldId = fieldIdByName.get(normalize(fieldName));
+    if (!fieldId) {
+      core.setFailed(`Project field '${fieldName}' が見つかりません。`);
+      return;
+    }
+
+    const options = optionIdByFieldName.get(normalize(fieldName));
+    if (!options) {
+      core.setFailed(`Project field '${fieldName}' の option 定義が見つかりません。`);
+      return;
+    }
+
+    const normalizedValue = normalize(rawValue);
+    if (!normalizedValue || normalizedValue === '_no response_') {
+      console.log(`Skip ${fieldName}: value is empty.`);
+      return;
+    }
+
+    const optionId = options.get(normalizedValue);
+    if (!optionId) {
+      core.setFailed(
+        `Project field '${fieldName}' に option '${rawValue}' が存在しません。利用可能: ${Array.from(options.keys()).join(', ')}`,
+      );
+      return;
+    }
+
+    const mutation = `
+      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+        updateProjectV2ItemFieldValue(
+          input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }
+        ) {
+          projectV2Item {
+            id
+          }
+        }
+      }
+    `;
+
+    await github.graphql(mutation, {
+      projectId: process.env.PROJECT_ID,
+      itemId: process.env.ITEM_ID,
+      fieldId,
+      optionId,
+    });
+  }
+
+  /**
+   * @param {string} fieldName フィールド名
+   * @param {string} rawValue 設定値
+   * @returns {Promise<void>}
+   */
+  async function setDateField(fieldName, rawValue) {
+    const value = mapDate(rawValue);
+    if (!value || normalize(value) === '_no response_') {
+      console.log(`Skip ${fieldName}: value is empty.`);
+      return;
+    }
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      core.setFailed(`${fieldName} は YYYY-MM-DD 形式で指定してください。受信値: ${rawValue}`);
+      return;
+    }
+
+    const fieldId = fieldIdByName.get(normalize(fieldName));
+    if (!fieldId) {
+      core.setFailed(`Project field '${fieldName}' が見つかりません。`);
+      return;
+    }
+
+    const mutation = `
+      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+        updateProjectV2ItemFieldValue(
+          input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { date: $date }
+          }
+        ) {
+          projectV2Item {
+            id
+          }
+        }
+      }
+    `;
+
+    await github.graphql(mutation, {
+      projectId: process.env.PROJECT_ID,
+      itemId: process.env.ITEM_ID,
+      fieldId,
+      date: value,
+    });
+  }
+
+  if (process.env.STATUS) {
+    await setSingleSelectField('Status', process.env.STATUS);
+  }
+
+  if (process.env.PRIORITY) {
+    await setSingleSelectField('Priority', mapPriority(process.env.PRIORITY));
+  }
+
+  if (process.env.START_DATE) {
+    await setDateField('Start date', process.env.START_DATE);
+  }
+
+  if (process.env.TARGET_DATE) {
+    await setDateField('Target date', process.env.TARGET_DATE);
+  }
+}
+
+module.exports = run;
+module.exports.helpers = {
+  buildFieldMaps,
+  mapDate,
+  mapPriority,
+  normalize,
+  safeParse,
+};

--- a/.github/workflows/scripts/set-project-fields.test.js
+++ b/.github/workflows/scripts/set-project-fields.test.js
@@ -1,0 +1,163 @@
+/**
+ * @file set-project-fields.js の単体テスト
+ * @author 山内陽
+ */
+const assert = require('node:assert/strict');
+
+const run = require('./set-project-fields');
+const { helpers } = run;
+
+/**
+ * @returns {{ core: { setFailed(message: string): void, messages: string[] }, github: { graphql: (...args: unknown[]) => Promise<unknown> }, calls: Array<{ query: string, variables: Record<string, string> }> }}
+ */
+function createMocks() {
+  const messages = [];
+  const calls = [];
+
+  return {
+    core: {
+      messages,
+      setFailed(message) {
+        messages.push(message);
+      },
+    },
+    github: {
+      async graphql(query, variables) {
+        calls.push({ query, variables });
+        return { projectV2Item: { id: variables.itemId } };
+      },
+    },
+    calls,
+  };
+}
+
+function testMapPriority() {
+  assert.equal(helpers.mapPriority('2'), 'P2');
+  assert.equal(helpers.mapPriority('p4'), 'P4');
+  assert.equal(helpers.mapPriority('High'), 'HIGH');
+}
+
+function testSafeParseFailure() {
+  const { core } = createMocks();
+
+  const result = helpers.safeParse('FIELDS', '{invalid}', core);
+
+  assert.equal(result, null);
+  assert.equal(core.messages.length, 1);
+  assert.match(core.messages[0], /FIELDS の JSON 解析に失敗しました/);
+}
+
+async function testRunUpdatesAllFields() {
+  const { core, github, calls } = createMocks();
+  const env = {
+    PROJECT_ID: 'project-1',
+    ITEM_ID: 'item-1',
+    FIELDS: JSON.stringify({
+      Status: 'field-status',
+      Priority: 'field-priority',
+      'Start date': 'field-start',
+      'Target date': 'field-target',
+    }),
+    FIELD_OPTIONS: JSON.stringify({
+      Status: {
+        Ready: 'option-ready',
+      },
+      Priority: {
+        P2: 'option-p2',
+      },
+    }),
+    STATUS: 'Ready',
+    PRIORITY: '2',
+    START_DATE: '2026-04-20',
+    TARGET_DATE: '2026-04-30',
+  };
+
+  await run({
+    core,
+    github,
+    process: { env },
+  });
+
+  assert.equal(core.messages.length, 0);
+  assert.equal(calls.length, 4);
+  assert.deepEqual(
+    calls.map((call) => call.variables),
+    [
+      {
+        projectId: 'project-1',
+        itemId: 'item-1',
+        fieldId: 'field-status',
+        optionId: 'option-ready',
+      },
+      {
+        projectId: 'project-1',
+        itemId: 'item-1',
+        fieldId: 'field-priority',
+        optionId: 'option-p2',
+      },
+      {
+        projectId: 'project-1',
+        itemId: 'item-1',
+        fieldId: 'field-start',
+        date: '2026-04-20',
+      },
+      {
+        projectId: 'project-1',
+        itemId: 'item-1',
+        fieldId: 'field-target',
+        date: '2026-04-30',
+      },
+    ],
+  );
+}
+
+async function testRunFailsOnInvalidDate() {
+  const { core, github, calls } = createMocks();
+  const env = {
+    PROJECT_ID: 'project-1',
+    ITEM_ID: 'item-1',
+    FIELDS: JSON.stringify({
+      Priority: 'field-priority',
+      'Start date': 'field-start',
+    }),
+    FIELD_OPTIONS: JSON.stringify({
+      Priority: {
+        P1: 'option-p1',
+      },
+    }),
+    PRIORITY: 'P1',
+    START_DATE: '2026/04/20',
+  };
+
+  await run({
+    core,
+    github,
+    process: { env },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(core.messages.length, 1);
+  assert.match(core.messages[0], /Start date は YYYY-MM-DD 形式で指定してください/);
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const tests = [
+    ['mapPriority は数値を Project の優先度形式へ正規化する', testMapPriority],
+    ['safeParse は不正な JSON で失敗を記録する', testSafeParseFailure],
+    ['run は Status と Priority と日付フィールドを更新する', testRunUpdatesAllFields],
+    ['run は不正な日付形式で失敗し後続更新を止める', testRunFailsOnInvalidDate],
+  ];
+
+  for (const [name, testCase] of tests) {
+    await testCase();
+    console.log(`PASS ${name}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 概要
GitHub Project 連携用の Issue テンプレートと自動化 workflow を追加し、Project 反映処理をテスト可能な形で整備しました。

## 変更内容
- Task / Bug の Issue template と config を追加
- Issue 作成・更新時に GitHub Project へ追加し、Priority / Start date / Target date / Status を同期する workflow を追加
- Issue close 時に Project の Status を Done へ更新する workflow を追加
- Project フィールド更新用スクリプトを追加し、正常系と異常系の単体テストを追加
- `edited` イベント時の add-to-project 二重実行回避と、Project 未登録 Issue close 時の安全なスキップを追加

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
なし

## その他 (懸念点・共有事項)
- `dotnet format` は `.github` 配下のみの変更のため今回は未実行です。
- `PROJECT_TOKEN` 未設定時は workflow を warning で安全にスキップします。
