### PR TITLE
fix: repair invisible GitHub Project items

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -94,134 +94,31 @@ jobs:
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const issue = context.payload.issue;
-            const user = 'aptmara';
-            const projectNumber = 4;
-            const itemIdHint = process.env.ITEM_ID_HINT;
-
-            const projectQuery = `
-              query($login: String!, $number: Int!) {
-                user(login: $login) {
-                  projectV2(number: $number) {
-                    id
-                    fields(first: 50) {
-                      nodes {
-                        ... on ProjectV2Field { id name dataType }
-                        ... on ProjectV2SingleSelectField { id name dataType options { id name } }
-                      }
-                    }
-                  }
-                }
-              }
-            `;
-
-            const itemQuery = `
-              query($login: String!, $number: Int!, $first: Int!, $after: String) {
-                user(login: $login) {
-                  projectV2(number: $number) {
-                    items(first: $first, after: $after) {
-                      nodes {
-                        id
-                        content {
-                          ... on Issue { id number }
-                        }
-                      }
-                      pageInfo {
-                        hasNextPage
-                        endCursor
-                      }
-                    }
-                  }
-                }
-              }
-            `;
-
-            const addMutation = `
-              mutation($projectId: ID!, $contentId: ID!) {
-                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-                  item {
-                    id
-                  }
-                }
-              }
-            `;
-
-            async function findItemId() {
-              let after = null;
-
-              while (true) {
-                const response = await github.graphql(itemQuery, {
-                  login: user,
-                  number: projectNumber,
-                  first: 100,
-                  after,
-                });
-
-                const items = response.user.projectV2.items;
-                const hit = items.nodes.find((node) => node.content && node.content.number === issue.number);
-                if (hit) {
-                  return hit.id;
-                }
-
-                if (!items.pageInfo.hasNextPage) {
-                  return null;
-                }
-
-                after = items.pageInfo.endCursor;
-              }
+            const path = require('path');
+            const fs = require('fs');
+            const scriptPath = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/scripts/resolve-project-item.js');
+            if (!fs.existsSync(scriptPath)) {
+              core.setFailed(`Script not found: ${scriptPath}`);
+              return;
             }
 
-            const projectResponse = await github.graphql(projectQuery, {
-              login: user,
-              number: projectNumber,
+            const resolveProjectItem = require(scriptPath);
+            const result = await resolveProjectItem({
+              core,
+              github,
+              issue: context.payload.issue,
+              itemIdHint: process.env.ITEM_ID_HINT,
+              projectNumber: 4,
+              user: 'aptmara',
             });
-
-            const project = projectResponse.user.projectV2;
-            if (!project) {
-              core.setFailed(`Project ${projectNumber} was not found for user ${user}.`);
+            if (!result) {
               return;
             }
 
-            let itemId = itemIdHint || null;
-            if (!itemId) {
-              itemId = await findItemId();
-            }
-
-            if (!itemId) {
-              try {
-                const addResponse = await github.graphql(addMutation, {
-                  projectId: project.id,
-                  contentId: issue.node_id,
-                });
-                itemId = addResponse.addProjectV2ItemById.item.id;
-              } catch (error) {
-                console.log(`Add item fallback failed: ${error.message}`);
-                itemId = await findItemId();
-              }
-            }
-
-            if (!itemId) {
-              core.setFailed('Project item could not be resolved.');
-              return;
-            }
-
-            const fields = {};
-            const fieldOptions = {};
-            for (const field of project.fields.nodes) {
-              fields[field.name] = field.id;
-              if (field.options) {
-                const options = {};
-                for (const option of field.options) {
-                  options[option.name] = option.id;
-                }
-                fieldOptions[field.name] = options;
-              }
-            }
-
-            core.setOutput('project_id', project.id);
-            core.setOutput('item_id', itemId);
-            core.setOutput('fields', JSON.stringify(fields));
-            core.setOutput('field_options', JSON.stringify(fieldOptions));
+            core.setOutput('project_id', result.projectId);
+            core.setOutput('item_id', result.itemId);
+            core.setOutput('fields', JSON.stringify(result.fields));
+            core.setOutput('field_options', JSON.stringify(result.fieldOptions));
 
       - name: Set Project Fields
         if: steps.check-token.outputs.token_exists == 'true' && steps.project-data.outputs.project_id != ''

--- a/.github/workflows/scripts/resolve-project-item.js
+++ b/.github/workflows/scripts/resolve-project-item.js
@@ -1,0 +1,326 @@
+/**
+ * @file GitHub Project item の可視性を担保しつつ item を解決する補助スクリプト
+ * @author 山内陽
+ */
+const DEFAULT_REPAIR_ATTEMPTS = 3;
+const DEFAULT_VISIBILITY_WAIT_MS = 1500;
+
+const PROJECT_QUERY = `
+  query ResolveProjectData($login: String!, $number: Int!) {
+    user(login: $login) {
+      projectV2(number: $number) {
+        id
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2Field { id name dataType }
+            ... on ProjectV2SingleSelectField { id name dataType options { id name } }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const VISIBLE_ITEM_QUERY = `
+  query FindVisibleProjectItem($login: String!, $number: Int!, $first: Int!, $after: String) {
+    user(login: $login) {
+      projectV2(number: $number) {
+        items(first: $first, after: $after) {
+          nodes {
+            id
+            content {
+              ... on Issue { id number }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ISSUE_PROJECT_ITEMS_QUERY = `
+  query FindIssueProjectItems($issueId: ID!, $first: Int!) {
+    node(id: $issueId) {
+      ... on Issue {
+        projectItems(first: $first) {
+          nodes {
+            id
+            isArchived
+            project {
+              id
+              number
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ADD_ITEM_MUTATION = `
+  mutation AddProjectItem($projectId: ID!, $contentId: ID!) {
+    addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+      item {
+        id
+      }
+    }
+  }
+`;
+
+const DELETE_ITEM_MUTATION = `
+  mutation DeleteProjectItem($projectId: ID!, $itemId: ID!) {
+    deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+      deletedItemId
+    }
+  }
+`;
+
+/**
+ * @param {number} waitMs 待機時間
+ * @returns {Promise<void>}
+ */
+function sleep(waitMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, waitMs);
+  });
+}
+
+/**
+ * @param {Array<{ id: string, name: string, options?: Array<{ id: string, name: string }> }>} nodes Project field nodes
+ * @returns {{ fields: Record<string, string>, fieldOptions: Record<string, Record<string, string>> }}
+ */
+function buildProjectFieldData(nodes) {
+  const fields = {};
+  const fieldOptions = {};
+
+  for (const field of nodes || []) {
+    fields[field.name] = field.id;
+    if (field.options) {
+      const options = {};
+      for (const option of field.options) {
+        options[option.name] = option.id;
+      }
+
+      fieldOptions[field.name] = options;
+    }
+  }
+
+  return { fields, fieldOptions };
+}
+
+/**
+ * @param {{ github: { graphql: Function }, login: string, projectNumber: number, issueNumber: number }} params 入力値
+ * @returns {Promise<string | null>}
+ */
+async function findVisibleItemId({ github, login, projectNumber, issueNumber }) {
+  let after = null;
+
+  while (true) {
+    const response = await github.graphql(VISIBLE_ITEM_QUERY, {
+      after,
+      first: 100,
+      login,
+      number: projectNumber,
+    });
+
+    const items = response.user.projectV2.items;
+    const hit = items.nodes.find((node) => node.content && node.content.number === issueNumber);
+    if (hit) {
+      return hit.id;
+    }
+
+    if (!items.pageInfo.hasNextPage) {
+      return null;
+    }
+
+    after = items.pageInfo.endCursor;
+  }
+}
+
+/**
+ * @param {{ github: { graphql: Function }, issueId: string, projectId: string }} params 入力値
+ * @returns {Promise<string[]>}
+ */
+async function findInvisibleLinkedItemIds({ github, issueId, projectId }) {
+  const response = await github.graphql(ISSUE_PROJECT_ITEMS_QUERY, {
+    first: 20,
+    issueId,
+  });
+
+  return (response.node?.projectItems?.nodes || [])
+    .filter((node) => node.project && node.project.id === projectId && !node.isArchived)
+    .map((node) => node.id);
+}
+
+/**
+ * @param {{ github: { graphql: Function }, projectId: string, itemId: string }} params 入力値
+ * @returns {Promise<void>}
+ */
+async function deleteItem({ github, projectId, itemId }) {
+  await github.graphql(DELETE_ITEM_MUTATION, {
+    itemId,
+    projectId,
+  });
+}
+
+/**
+ * @param {{ github: { graphql: Function }, projectId: string, contentId: string }} params 入力値
+ * @returns {Promise<string>}
+ */
+async function addItem({ github, projectId, contentId }) {
+  const response = await github.graphql(ADD_ITEM_MUTATION, {
+    contentId,
+    projectId,
+  });
+
+  return response.addProjectV2ItemById.item.id;
+}
+
+/**
+ * @param {{
+ *   core: { setFailed(message: string): void },
+ *   github: { graphql: Function },
+ *   issue: { node_id: string, number: number },
+ *   itemIdHint?: string,
+ *   projectId: string,
+ *   projectNumber: number,
+ *   repairAttempts?: number,
+ *   user: string,
+ *   visibilityWaitMs?: number,
+ * }} params 入力値
+ * @returns {Promise<string | null>}
+ */
+async function resolveVisibleItemId({
+  core,
+  github,
+  issue,
+  itemIdHint,
+  projectId,
+  projectNumber,
+  repairAttempts = DEFAULT_REPAIR_ATTEMPTS,
+  user,
+  visibilityWaitMs = DEFAULT_VISIBILITY_WAIT_MS,
+}) {
+  const hintedId = itemIdHint || null;
+  const visibleId = await findVisibleItemId({
+    github,
+    issueNumber: issue.number,
+    login: user,
+    projectNumber,
+  });
+  if (visibleId) {
+    return visibleId;
+  }
+
+  for (let attempt = 1; attempt <= repairAttempts; attempt += 1) {
+    const invisibleItemIds = await findInvisibleLinkedItemIds({
+      github,
+      issueId: issue.node_id,
+      projectId,
+    });
+
+    for (const itemId of invisibleItemIds) {
+      console.log(`Delete invisible project item: ${itemId}`);
+      await deleteItem({ github, itemId, projectId });
+    }
+
+    const createdItemId = await addItem({
+      contentId: issue.node_id,
+      github,
+      projectId,
+    });
+
+    console.log(`Repair attempt ${attempt}: created item ${createdItemId}`);
+    await sleep(visibilityWaitMs);
+
+    const repairedItemId = await findVisibleItemId({
+      github,
+      issueNumber: issue.number,
+      login: user,
+      projectNumber,
+    });
+    if (repairedItemId) {
+      return repairedItemId;
+    }
+  }
+
+  core.setFailed(
+    `Project item for issue #${issue.number} は作成できましたが、一覧に可視化されませんでした。GitHub Projects 側の不整合の可能性があります。`,
+  );
+  return hintedId;
+}
+
+/**
+ * @param {{
+ *   core: { setFailed(message: string): void },
+ *   github: { graphql: Function },
+ *   issue: { node_id: string, number: number },
+ *   itemIdHint?: string,
+ *   projectNumber: number,
+ *   user: string,
+ * }} params 入力値
+ * @returns {Promise<{ projectId: string, itemId: string, fields: Record<string, string>, fieldOptions: Record<string, Record<string, string>> } | null>}
+ */
+async function resolveProjectItem(params) {
+  const {
+    core,
+    github,
+    issue,
+    itemIdHint,
+    projectNumber,
+    user,
+  } = params;
+
+  const projectResponse = await github.graphql(PROJECT_QUERY, {
+    login: user,
+    number: projectNumber,
+  });
+
+  const project = projectResponse.user.projectV2;
+  if (!project) {
+    core.setFailed(`Project ${projectNumber} was not found for user ${user}.`);
+    return null;
+  }
+
+  const itemId = await resolveVisibleItemId({
+    core,
+    github,
+    issue,
+    itemIdHint,
+    projectId: project.id,
+    projectNumber,
+    user,
+  });
+  if (!itemId) {
+    return null;
+  }
+
+  const { fields, fieldOptions } = buildProjectFieldData(project.fields.nodes);
+  return {
+    fieldOptions,
+    fields,
+    itemId,
+    projectId: project.id,
+  };
+}
+
+module.exports = resolveProjectItem;
+module.exports.helpers = {
+  ADD_ITEM_MUTATION,
+  buildProjectFieldData,
+  DEFAULT_REPAIR_ATTEMPTS,
+  DEFAULT_VISIBILITY_WAIT_MS,
+  DELETE_ITEM_MUTATION,
+  findInvisibleLinkedItemIds,
+  findVisibleItemId,
+  ISSUE_PROJECT_ITEMS_QUERY,
+  PROJECT_QUERY,
+  resolveVisibleItemId,
+  sleep,
+  VISIBLE_ITEM_QUERY,
+};

--- a/.github/workflows/scripts/resolve-project-item.test.js
+++ b/.github/workflows/scripts/resolve-project-item.test.js
@@ -1,0 +1,294 @@
+/**
+ * @file resolve-project-item.js の単体テスト
+ * @author 山内陽
+ */
+const assert = require('node:assert/strict');
+
+const resolveProjectItem = require('./resolve-project-item');
+const { helpers } = resolveProjectItem;
+
+/**
+ * @param {Array<unknown>} values 返却値一覧
+ * @returns {{ graphql(query: string, variables: Record<string, unknown>): Promise<unknown>, calls: Array<{ query: string, variables: Record<string, unknown> }> }}
+ */
+function createGithubMock(values) {
+  const queue = [...values];
+  const calls = [];
+
+  return {
+    calls,
+    async graphql(query, variables) {
+      calls.push({ query, variables });
+      if (queue.length === 0) {
+        throw new Error('Mock response is exhausted.');
+      }
+
+      return queue.shift();
+    },
+  };
+}
+
+/**
+ * @returns {{ messages: string[], setFailed(message: string): void }}
+ */
+function createCoreMock() {
+  const messages = [];
+  return {
+    messages,
+    setFailed(message) {
+      messages.push(message);
+    },
+  };
+}
+
+function testBuildProjectFieldData() {
+  const result = helpers.buildProjectFieldData([
+    {
+      id: 'field-status',
+      name: 'Status',
+      options: [
+        { id: 'ready', name: 'Ready' },
+      ],
+    },
+    {
+      id: 'field-start',
+      name: 'Start date',
+    },
+  ]);
+
+  assert.deepEqual(result, {
+    fieldOptions: {
+      Status: {
+        Ready: 'ready',
+      },
+    },
+    fields: {
+      'Start date': 'field-start',
+      Status: 'field-status',
+    },
+  });
+}
+
+async function testResolveProjectItemReturnsExistingVisibleItem() {
+  const github = createGithubMock([
+    {
+      user: {
+        projectV2: {
+          fields: {
+            nodes: [
+              { id: 'field-status', name: 'Status', options: [] },
+            ],
+          },
+          id: 'project-1',
+        },
+      },
+    },
+    {
+      user: {
+        projectV2: {
+          items: {
+            nodes: [
+              { content: { number: 158 }, id: 'visible-item-1' },
+            ],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+        },
+      },
+    },
+  ]);
+  const core = createCoreMock();
+
+  const result = await resolveProjectItem({
+    core,
+    github,
+    issue: {
+      node_id: 'issue-node-1',
+      number: 158,
+    },
+    itemIdHint: '',
+    projectNumber: 4,
+    user: 'aptmara',
+  });
+
+  assert.deepEqual(result, {
+    fieldOptions: {
+      Status: {},
+    },
+    fields: {
+      Status: 'field-status',
+    },
+    itemId: 'visible-item-1',
+    projectId: 'project-1',
+  });
+  assert.equal(core.messages.length, 0);
+  assert.equal(github.calls.length, 2);
+}
+
+async function testResolveVisibleItemRepairsInvisibleItem() {
+  const github = createGithubMock([
+    {
+      user: {
+        projectV2: {
+          items: {
+            nodes: [],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      node: {
+        projectItems: {
+          nodes: [
+            {
+              id: 'invisible-item-1',
+              isArchived: false,
+              project: {
+                id: 'project-1',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      deleteProjectV2Item: {
+        deletedItemId: 'invisible-item-1',
+      },
+    },
+    {
+      addProjectV2ItemById: {
+        item: {
+          id: 'new-item-1',
+        },
+      },
+    },
+    {
+      user: {
+        projectV2: {
+          items: {
+            nodes: [
+              { content: { number: 158 }, id: 'new-item-1' },
+            ],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+        },
+      },
+    },
+  ]);
+  const core = createCoreMock();
+
+  const result = await helpers.resolveVisibleItemId({
+    core,
+    github,
+    issue: {
+      node_id: 'issue-node-1',
+      number: 158,
+    },
+    itemIdHint: '',
+    projectId: 'project-1',
+    projectNumber: 4,
+    user: 'aptmara',
+    visibilityWaitMs: 0,
+  });
+
+  assert.equal(result, 'new-item-1');
+  assert.equal(core.messages.length, 0);
+  assert.equal(github.calls[2].variables.itemId, 'invisible-item-1');
+}
+
+async function testResolveVisibleItemFailsWhenStillInvisible() {
+  const github = createGithubMock([
+    {
+      user: {
+        projectV2: {
+          items: {
+            nodes: [],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+        },
+      },
+    },
+    {
+      node: {
+        projectItems: {
+          nodes: [],
+        },
+      },
+    },
+    {
+      addProjectV2ItemById: {
+        item: {
+          id: 'new-item-1',
+        },
+      },
+    },
+    {
+      user: {
+        projectV2: {
+          items: {
+            nodes: [],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+        },
+      },
+    },
+  ]);
+  const core = createCoreMock();
+
+  const result = await helpers.resolveVisibleItemId({
+    core,
+    github,
+    issue: {
+      node_id: 'issue-node-1',
+      number: 158,
+    },
+    itemIdHint: '',
+    projectId: 'project-1',
+    projectNumber: 4,
+    repairAttempts: 1,
+    user: 'aptmara',
+    visibilityWaitMs: 0,
+  });
+
+  assert.equal(result, null);
+  assert.equal(core.messages.length, 1);
+  assert.match(core.messages[0], /一覧に可視化されませんでした/);
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const tests = [
+    ['buildProjectFieldData は field と option を展開する', testBuildProjectFieldData],
+    ['resolveProjectItem は既に見えている item をそのまま返す', testResolveProjectItemReturnsExistingVisibleItem],
+    ['resolveVisibleItemId は不可視 item を削除再登録して可視 item を返す', testResolveVisibleItemRepairsInvisibleItem],
+    ['resolveVisibleItemId は再登録後も不可視なら失敗を記録する', testResolveVisibleItemFailsWhenStillInvisible],
+  ];
+
+  for (const [name, testCase] of tests) {
+    await testCase();
+    console.log(`PASS ${name}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 概要
GitHub Projects 側で issue が Project に紐づいているのに `projectV2.items` や board UI に現れないケースに対し、opened / edited 時の自動修復処理を追加しました。

## 変更内容
- `Get Project Data` の Project item 解決処理を `resolve-project-item.js` に分離
- `issue.projectItems` には存在するが `projectV2.items` に見えない item を検出する処理を追加
- 不可視 item を検出した場合、削除して再登録し、一覧に見える item を再解決する自己修復ロジックを追加
- 上記ロジックの単体テストを追加
- 既存の Project field 同期テストは維持し、日付正規化の挙動も継続確認

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
なし

## その他 (懸念点・共有事項)
- `dotnet format` は `.github` 配下のみの変更のため今回は未実行です。
- GitHub Projects 自体の不整合が継続する場合は workflow を fail にして検知できるようにしています。
