### PR TITLE
[#165] 実行フェーズ中の行動UIを強調表示

### DIFF
--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -48,6 +48,7 @@ namespace CreatorKousien.Battle
 
         // 実行フェーズで1手ずつ取り出すためのアクション予約リスト
         private Queue<ActionRuntimeData> _actionQueue = new Queue<ActionRuntimeData>();
+        private int _currentTimelineActionIndex = -1;
 
         /// <summary>
         /// バトル開始時の初期化処理
@@ -58,6 +59,7 @@ namespace CreatorKousien.Battle
             _dispatcher = dispatcher;
             _eventBus = eventBus;
             _phaseManager = new PhaseManager();
+            _currentTimelineActionIndex = -1;
 
             _commandPhase = new CommandPhaseState(this, handState);
             _actionPhase = new ActionPhaseState(this);
@@ -84,6 +86,8 @@ namespace CreatorKousien.Battle
         public void SetActionQueue(List<ActionRuntimeData> actions)
         {
             _actionQueue.Clear();
+            _currentTimelineActionIndex = -1;
+            _eventBus?.PublishTimelineActionExecutionChanged(-1);
             foreach (var action in actions)
             {
                 _actionQueue.Enqueue(action);
@@ -99,12 +103,16 @@ namespace CreatorKousien.Battle
             if (_actionQueue.Count == 0)
             {
                 // 全ての手順が終了したらターン終了フェーズへ
+                _currentTimelineActionIndex = -1;
+                _eventBus?.PublishTimelineActionExecutionChanged(-1);
                 _phaseManager.TransitionTo(PhaseType.TurnEnd);
                 return;
             }
 
             // キューから1手取り出す
             var nextAction = _actionQueue.Dequeue();
+            _currentTimelineActionIndex++;
+            _eventBus?.PublishTimelineActionExecutionChanged(_currentTimelineActionIndex);
 
             // チケットのカテゴリに応じて、適切なCommandとしてDispatcherに投げる
             switch (nextAction.Type)

--- a/Assets/Scripts/Battle/View/TurnDisplayView.cs
+++ b/Assets/Scripts/Battle/View/TurnDisplayView.cs
@@ -29,6 +29,12 @@ namespace CreatorKousien.View.UI
 
         [Header("アクションがない場合のアイコン")]
         [SerializeField] private Sprite emptyIcon;              /// アクションがない場合のアイコン
+        [Header("実行中ハイライト設定")]
+        [SerializeField] private Color timelineSlotColor = Color.white;
+        [SerializeField] private Color activeTimelineSlotColor = new Color(1f, 0.85f, 0.2f, 1f);
+        [SerializeField] private Vector3 activeTimelineSlotScale = new Vector3(1.15f, 1.15f, 1f);
+
+        private int _activeTimelineIndex = -1;
 
         /// <summary>
         /// 初期化
@@ -36,6 +42,7 @@ namespace CreatorKousien.View.UI
         public void Initialize(GameEventBus eventBus)
         {
             eventBus.OnTimelineUpdated += UpdateDisplay;
+            eventBus.OnTimelineActionExecutionChanged += UpdateExecutionHighlight;
             ClearDisplay();
         }
 
@@ -52,7 +59,8 @@ namespace CreatorKousien.View.UI
                 {
                     slot.gameObject.SetActive(true);            // 常に表示しておく！
                     slot.sprite = emptyIcon;                    // デフォルトは「空の枠」
-                    slot.color = new Color(1f, 1f, 1f, 0.3f);   // 未入力感を持たせるため半透明(Alpha 0.3)にする
+                    slot.color = new Color(timelineSlotColor.r, timelineSlotColor.g, timelineSlotColor.b, 0.3f);   // 未入力感を持たせるため半透明(Alpha 0.3)にする
+                    slot.rectTransform.localScale = Vector3.one;
                 }
             }
         }
@@ -77,7 +85,7 @@ namespace CreatorKousien.View.UI
                     if (i < playerActions.Count)
                     {
                         timelineSlots[pSlotIndex].sprite = GetIcon(playerActions[i]);
-                        timelineSlots[pSlotIndex].color = Color.white;
+                        timelineSlots[pSlotIndex].color = timelineSlotColor;
                     }
                 }
 
@@ -88,10 +96,12 @@ namespace CreatorKousien.View.UI
                     if (i < enemyActions.Count)
                     {
                         timelineSlots[eSlotIndex].sprite = GetIcon(enemyActions[i]);
-                        timelineSlots[eSlotIndex].color = Color.white;
+                        timelineSlots[eSlotIndex].color = timelineSlotColor;
                     }
                 }
             }
+
+            ApplyExecutionHighlight();
         }
 
 
@@ -110,6 +120,44 @@ namespace CreatorKousien.View.UI
                 case ActionType.Wait:
                 case ActionType.Guard: return waitIcon;
                 default: return unknownIcon;
+            }
+        }
+
+        /// <summary>
+        /// 実行中のタイムライン枠を更新します。
+        /// </summary>
+        /// <param name="activeTimelineIndex">強調するタイムライン枠。強調解除時は-1</param>
+        private void UpdateExecutionHighlight(int activeTimelineIndex)
+        {
+            _activeTimelineIndex = activeTimelineIndex;
+            ApplyExecutionHighlight();
+        }
+
+        /// <summary>
+        /// 現在の実行インデックスに応じてタイムラインの見た目を調整します。
+        /// </summary>
+        private void ApplyExecutionHighlight()
+        {
+            if (timelineSlots == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < timelineSlots.Count; i++)
+            {
+                Image slot = timelineSlots[i];
+                if (slot == null)
+                {
+                    continue;
+                }
+
+                bool hasAction = slot.sprite != null && slot.sprite != emptyIcon;
+                bool isActive = hasAction && i == _activeTimelineIndex;
+
+                slot.color = hasAction
+                    ? (isActive ? activeTimelineSlotColor : timelineSlotColor)
+                    : new Color(timelineSlotColor.r, timelineSlotColor.g, timelineSlotColor.b, 0.3f);
+                slot.rectTransform.localScale = isActive ? activeTimelineSlotScale : Vector3.one;
             }
         }
     }

--- a/Assets/Scripts/Core/GameEventBus.cs
+++ b/Assets/Scripts/Core/GameEventBus.cs
@@ -64,6 +64,11 @@ namespace CreatorKousien.Core
         /// </summary>
         public event System.Action<List<ActionType>, List<ActionType>> OnTimelineUpdated;
 
+        /// <summary>
+        /// 実行フェーズで現在消化中のタイムライン枠を通知するイベント
+        /// </summary>
+        public event Action<int> OnTimelineActionExecutionChanged;
+
 
         /// <summary>
         /// アクターの死亡を通知するイベント
@@ -237,6 +242,15 @@ namespace CreatorKousien.Core
         public void PublishTimelineUpdated(List<ActionType> enemyActions, List<ActionType> playerActions)
         {
             OnTimelineUpdated?.Invoke(enemyActions, playerActions);
+        }
+
+        /// <summary>
+        /// 実行中のタイムライン枠更新イベントを発火するメソッド
+        /// </summary>
+        /// <param name="timelineIndex">強調するタイムライン枠。強調解除時は-1</param>
+        public void PublishTimelineActionExecutionChanged(int timelineIndex)
+        {
+            OnTimelineActionExecutionChanged?.Invoke(timelineIndex);
         }
     }
 }


### PR DESCRIPTION
## 概要
実行フェーズ中に、タイムライン上で現在消化中の行動UIが分かるように強調表示を追加しました。

## 変更内容
- `TurnManager` で実行中タイムライン枠のインデックスを管理し、開始・進行・終了時にイベント通知するように変更
- `GameEventBus` に実行中タイムライン枠の通知イベントを追加
- `TurnDisplayView` で実行中スロットだけ色とスケールを変えて強調表示する処理を追加

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #165

## その他 (懸念点・共有事項)
- `Unity_ValidateScript` では対象3ファイルの検証を通過しています
- Unity コンソール上のエラーはありません
- `dotnet format` は restore / 初回セットアップ側で失敗したため未完了です
