### PR TITLE
feature:敵の最大予告個数を定数追加

### DIFF
--- a/Assets/Scenes/Select.unity
+++ b/Assets/Scenes/Select.unity
@@ -801,8 +801,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf026e860459d0a4db54fa8235a0b621, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CreatorKousien.Battle.TurnManager
-  _maxInputCount: 3
-  _commandTimeLimit: 5
+  _maxInputCount: 1
+  _commandTimeLimit: 2
+  _visibleEnemyAction: 5
 --- !u!114 &811160245
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battle/Turn/States/CommandPhaseState.cs
+++ b/Assets/Scripts/Battle/Turn/States/CommandPhaseState.cs
@@ -64,13 +64,17 @@ namespace CreatorKousien.Battle
             // 新しい思考を始める前に、画面上の前回の予告を全て消す
             _owner.EventBus.PublishClearAllTelegraphs();
 
+            // 敵の最大予告数 - 今の保持してる手数
+            int rollEnemyActTimes = _owner.VisibleEnemyAction - _owner.EnemyActions.Count;
+
             // フェーズ開始と同時に、全てのエネミーの3手分を計算させる
             var planCommand = new EnemyActionCommand((teamPlan) =>
             {
-                _enemyPlannedActions = teamPlan;
+                _owner.AddEnemyActionTelegraph(teamPlan);
+                //_enemyPlannedActions = teamPlan;
                 UpdateTimelineUI();
                 Debug.Log($"[Command Phase] 敵チーム全体の3手を受領しました！");
-            });
+            },rollEnemyActTimes);
 
             _owner.Dispatcher.Dispatch(planCommand);
 
@@ -98,9 +102,6 @@ namespace CreatorKousien.Battle
             // 時間ゲージのカウントダウンロジック、カード選択等
             // タイムアップしているか、3手入力済みなら何もしない
             if (_isTimeUp || _playerSelectedActions.Count >= _owner.MaxInputCount) return;
-
-            // 既にタイムアップしているか、3手入力済みなら何もしない
-            if (_isTimeUp || _playerSelectedActions.Count >= 3) return;
 
             // タイマーを減算
             _currentTime -= Time.deltaTime;
@@ -194,11 +195,11 @@ namespace CreatorKousien.Battle
         /// <param name="action"></param>
         public void AddPlayerAction(ActionRuntimeData action)
         {
-            if (_playerSelectedActions.Count >= 3) return;
+            if (_playerSelectedActions.Count >= _owner.MaxInputCount) return;
 
             _playerSelectedActions.Add(action);
             UpdateTimelineUI();
-            Debug.Log($"[Command] プレイヤーのアクションを予約: {action.Type} ({_playerSelectedActions.Count}/3)");
+            Debug.Log($"[Command] プレイヤーのアクションを予約: {action.Type} ({_playerSelectedActions.Count}/{_owner.MaxInputCount})");
 
             // 3手選んだら自動で実行フェーズへ
             if (_playerSelectedActions.Count == _owner.MaxInputCount)
@@ -210,7 +211,10 @@ namespace CreatorKousien.Battle
         private void FinishPhase()
         {
             // プレイヤーと敵のアクションを交互に並べて、TurnManagerに渡す
-            List<BattleStep> steps = CreateBattleSteps(_playerSelectedActions, _enemyPlannedActions);
+            //List<BattleStep> steps = CreateBattleSteps(_playerSelectedActions, _enemyPlannedActions);
+
+            var steps = new List<BattleStep>();
+            steps.Add(new BattleStep(_playerSelectedActions[0], _owner.GetEnemyActionTelegraph()));
 
             _owner.SetActionQueue(steps);
             _owner.TransitionTo(PhaseType.Action);

--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using CreatorKousien.Core;
 using CreatorKousien.Data;
 using UnityEngine.Rendering;
+using System.Linq;
 
 namespace CreatorKousien.Battle
 {
@@ -72,7 +73,8 @@ namespace CreatorKousien.Battle
         private Queue<BattleStep> _stepQueue = new Queue<BattleStep>();
         private Queue<ActionRuntimeData> _microQueue = new Queue<ActionRuntimeData>();
         // 敵の行動のみをスタックするキュー
-        private Queue<ActionRuntimeData> _enemyActionQueue = new Queue<ActionRuntimeData>();
+        private List<ActionRuntimeData> _enemyActions = new List<ActionRuntimeData>();
+        public IReadOnlyList<ActionRuntimeData> EnemyActions =>_enemyActions;
 
         public List<ActionRuntimeData> _enemyTelegraphs = new List<ActionRuntimeData>();
 
@@ -326,7 +328,7 @@ namespace CreatorKousien.Battle
         {
             foreach (var action in data)
             {
-                _enemyActionQueue.Enqueue(action);
+                _enemyActions.Add(action);
             }
         }
 
@@ -336,7 +338,10 @@ namespace CreatorKousien.Battle
         /// <returns></returns>
         public ActionRuntimeData GetEnemyActionTelegraph()
         {
-            return _enemyActionQueue.Dequeue();
+            ActionRuntimeData action;
+            action = _enemyActions.FirstOrDefault();
+            _enemyActions.Remove(action);
+            return action;
         }
     }
 }

--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -35,6 +35,7 @@ namespace CreatorKousien.Battle
         [Header("コマンドフェーズの設定")]
         [SerializeField] private int _maxInputCount = 3;        // プレイヤーがコマンドフェーズで入力できる最大アクション数
         [SerializeField] private float _commandTimeLimit = 3f;  // コマンドフェーズの時間制限（秒）
+        [SerializeField] private int _visibleEnemyAction = 5;   // コマンドフェーズで視認可能な敵の行動個数
 
         /// <summary>
         /// 最大入力数
@@ -46,6 +47,10 @@ namespace CreatorKousien.Battle
         /// </summary>
         public float CommandTimeLimit => _commandTimeLimit;
 
+        /// <summary>
+        /// 敵の最大行動視認可能数
+        /// </summary>
+        public int VisibleEnemyAction => _visibleEnemyAction;
 
         /// <summary>
         /// プレイヤーがカードを使ったことを通知するイベント
@@ -66,6 +71,10 @@ namespace CreatorKousien.Battle
         // ステップ単位のキューと、そのステップ内で順番に処理するマイクロキュー
         private Queue<BattleStep> _stepQueue = new Queue<BattleStep>();
         private Queue<ActionRuntimeData> _microQueue = new Queue<ActionRuntimeData>();
+        // 敵の行動のみをスタックするキュー
+        private Queue<ActionRuntimeData> _enemyActionQueue = new Queue<ActionRuntimeData>();
+
+        public List<ActionRuntimeData> _enemyTelegraphs = new List<ActionRuntimeData>();
 
         // このステップでキャンセルされたアクターのIDのリスト
         private HashSet<int> _cancelledActorsThisStep = new HashSet<int>();
@@ -282,7 +291,6 @@ namespace CreatorKousien.Battle
             }
         }
 
-
         /// <summary>
         /// 敵がアクションを決定した後、Commandフェーズから呼び出される想定のメソッド。（デバック用なので改変しても大丈夫）
         /// </summary>
@@ -308,6 +316,27 @@ namespace CreatorKousien.Battle
                 return _commandPhase.IsSlotUsed(slot);
             }
             return false;
+        }
+
+        /// <summary>
+        /// 敵の行動予告を格納する
+        /// </summary>
+        /// <param name="data"></param>
+        public void AddEnemyActionTelegraph(List<ActionRuntimeData> data)
+        {
+            foreach (var action in data)
+            {
+                _enemyActionQueue.Enqueue(action);
+            }
+        }
+
+        /// <summary>
+        /// 敵の行動予告を取得
+        /// </summary>
+        /// <returns></returns>
+        public ActionRuntimeData GetEnemyActionTelegraph()
+        {
+            return _enemyActionQueue.Dequeue();
         }
     }
 }

--- a/Assets/Scripts/Command/Enemy/EnemyActionCommand.cs
+++ b/Assets/Scripts/Command/Enemy/EnemyActionCommand.cs
@@ -20,9 +20,12 @@ namespace CreatorKousien.Command
         // 全てのエネミーのプランをActorIDとキーにして受けとる
         public Action<List<ActionRuntimeData>> OnPlanGenerated { get; }
 
-        public EnemyActionCommand(Action<List<ActionRuntimeData>> onPlanGenerated)
+        public int RollEnemyActTimes { get; }
+
+        public EnemyActionCommand(Action<List<ActionRuntimeData>> onPlanGenerated, int rollEnemyActTimes)
         {
             OnPlanGenerated = onPlanGenerated;
+            RollEnemyActTimes = rollEnemyActTimes;
         }
     }
 }

--- a/Assets/Scripts/UseCase/Enemy/EnemyActionUseCase.cs
+++ b/Assets/Scripts/UseCase/Enemy/EnemyActionUseCase.cs
@@ -54,8 +54,8 @@ namespace CreatorKousien.UseCase
         public void Execute(EnemyActionCommand command)
         {
             // 敵チーム全体の「合計3手」のプランを作成
-            List<ActionRuntimeData> teamPlan = PlanTeamActions();
-
+            List<ActionRuntimeData> teamPlan = PlanTeamActions(command.RollEnemyActTimes);
+            
             // コマンドの報告書に結果を書き込む
             command.OnPlanGenerated?.Invoke(teamPlan);
 
@@ -66,7 +66,7 @@ namespace CreatorKousien.UseCase
         /// 存在している全敵の中からステップごとに1体を指名し、チーム全体で3手のプランを作る
         /// </summary>
         /// <returns></returns>
-        private List<ActionRuntimeData> PlanTeamActions()
+        private List<ActionRuntimeData> PlanTeamActions(int rollEnemyActTimes)
         {
             var plan = new List<ActionRuntimeData>();
             var aliveEnemyIds = _enemySystem.GetAllAliveEnemyIds();
@@ -82,7 +82,7 @@ namespace CreatorKousien.UseCase
             }
 
             // チーム全体で3手分をループ
-            for (int step = 0; step < 3; step++)
+            for (int step = 0; step < rollEnemyActTimes; step++)
             {
                 // このステップで行動するエネミーを1体「ランダム」で指名する
                 int actingEnemyId = aliveEnemyIds[Random.Range(0, aliveEnemyIds.Count)];


### PR DESCRIPTION
キューのスタックと取得関数を作成

## 概要
UIで予告個数の制御をしやすくするために定数を追加
行動のキューの使用を変更するため新規キューを作成
それに応じた追加、取得関数を作成

## 変更内容
- TurnManager.csに定数、キュー、リストを追加
- 追加したキューへの追加、取得関数を作成

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [ o ] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ o ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [ o ] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [ o ] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ o ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ o ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ o ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #177 

## その他 (懸念点・共有事項)
04/25の昼までに頑張ります
