### PR TITLE
feat: 敵システム基盤とUI統合の実装 (#210, #211)

### DIFF
--- a/Assets/Game.meta
+++ b/Assets/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eae45243ead5209468552fd310da48fe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Enemy.meta
+++ b/Assets/Game/Enemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99a2e93ffbf47604eaa5e7ab49299d76
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Enemy/Enemy_01_Definition.asset
+++ b/Assets/Game/Enemy/Enemy_01_Definition.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c359e2404c41384c91cd27762a269b0, type: 3}
+  m_Name: Enemy_01_Definition
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.EnemyDefinition
+  EnemyId: Enemy_01
+  MaxGauge: 100
+  GaugeIncreaseRate: 8
+  MaxHp: 300
+  DownDuration: 5
+  HasBarrier: 0
+  BarrierDamageReduction: 0.5

--- a/Assets/Game/Enemy/Enemy_01_Definition.asset.meta
+++ b/Assets/Game/Enemy/Enemy_01_Definition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cb55c9a8a363064c9bf094f77b06186
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Proto_G_UIDebug.unity
+++ b/Assets/Scenes/Proto_G_UIDebug.unity
@@ -119,6 +119,81 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &6468319
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6468320}
+  - component: {fileID: 6468322}
+  - component: {fileID: 6468321}
+  m_Layer: 0
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6468320
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6468319}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 497532694}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6468321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6468319}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.8, b: 0.2, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &6468322
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6468319}
+  m_CullTransparentMesh: 1
 --- !u!1 &34160632
 GameObject:
   m_ObjectHideFlags: 0
@@ -255,6 +330,42 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &497532693
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 497532694}
+  m_Layer: 0
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &497532694
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 497532693}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6468320}
+  m_Father: {fileID: 1404977189}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &614631395
 GameObject:
   m_ObjectHideFlags: 0
@@ -388,6 +499,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1629464627}
+  - {fileID: 1404977189}
   m_Father: {fileID: 614631399}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -511,6 +623,78 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 883690157}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1118578336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1118578340}
+  - component: {fileID: 1118578339}
+  - component: {fileID: 1118578338}
+  - component: {fileID: 1118578337}
+  m_Layer: 0
+  m_Name: EnemyController_Enemy_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1118578337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1118578336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 032a47519f0c83f4b887eec623df58d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.EnemyController
+  _definition: {fileID: 11400000, guid: 4cb55c9a8a363064c9bf094f77b06186, type: 2}
+--- !u!114 &1118578338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1118578336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a969eb88586cb684c940001ea1d240ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.BarrierController
+  _damageReductionRate: 0.5
+--- !u!114 &1118578339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1118578336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c3e431e464f0e148ab2cc43c18642f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.EnemyAttackGauge
+--- !u!4 &1118578340
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1118578336}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -888,6 +1072,114 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1404977188
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1404977189}
+  - component: {fileID: 1404977191}
+  - component: {fileID: 1404977190}
+  m_Layer: 0
+  m_Name: EnemyHpBar_Enemy_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1404977189
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1404977188}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1887756723}
+  - {fileID: 497532694}
+  m_Father: {fileID: 715308311}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1404977190
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1404977188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a0a4cb610e4b344ba7ddf7abfb949b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Presentation.UI.EnemyHealthBar
+  _targetEnemyId: Enemy_01
+  _hpSlider: {fileID: 1404977191}
+  _hpFillImage: {fileID: 6468321}
+  _highHpColor: {r: 0.2, g: 0.8, b: 0.2, a: 1}
+  _midHpColor: {r: 0.9, g: 0.7, b: 0.1, a: 1}
+  _lowHpColor: {r: 0.9, g: 0.2, b: 0.2, a: 1}
+--- !u!114 &1404977191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1404977188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 6468320}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1560621006
 GameObject:
   m_ObjectHideFlags: 0
@@ -1130,6 +1422,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1853016451}
+  m_CullTransparentMesh: 1
+--- !u!1 &1887756722
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1887756723}
+  - component: {fileID: 1887756725}
+  - component: {fileID: 1887756724}
+  m_Layer: 0
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1887756723
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887756722}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1404977189}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1887756724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887756722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1, g: 0.1, b: 0.1, a: 0.8}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1887756725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887756722}
   m_CullTransparentMesh: 1
 --- !u!1 &1915793871
 GameObject:
@@ -1479,3 +1846,4 @@ SceneRoots:
   - {fileID: 614631399}
   - {fileID: 2141273930}
   - {fileID: 1273596990}
+  - {fileID: 1118578340}

--- a/Assets/Scripts/Core/Enemy.meta
+++ b/Assets/Scripts/Core/Enemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af71796bdd0248f4ba97d5dffd7b9310
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Enemy/BarrierController.cs
+++ b/Assets/Scripts/Core/Enemy/BarrierController.cs
@@ -1,0 +1,47 @@
+// 制作者: 山内陽
+using UnityEngine;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// IBarrierの標準実装（割合軽減バリア）。
+    /// 将来的に属性対応バリアや多層バリアへ差し替える際は
+    /// IBarrierを実装した別クラスを作り、EnemyDefinitionに型指定フィールドを追加する。
+    /// </summary>
+    public class BarrierController : MonoBehaviour, IBarrier
+    {
+        [SerializeField]
+        [Tooltip("ゲージダメージの軽減割合。0=軽減なし, 1=完全無効。EnemyDefinitionで上書きされる。")]
+        [Range(0f, 1f)]
+        private float _damageReductionRate = 0.5f;
+
+        private bool _isActive;
+
+        /// <inheritdoc/>
+        public bool IsActive => _isActive;
+
+        /// <summary>
+        /// EnemyDefinitionの値で初期化する。
+        /// </summary>
+        /// <param name="hasBarrier">バリアの有無</param>
+        /// <param name="reductionRate">ダメージ軽減割合（0〜1）</param>
+        public void Initialize(bool hasBarrier, float reductionRate)
+        {
+            _isActive = hasBarrier;
+            _damageReductionRate = reductionRate;
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// バリア有効時: rawDamage × (1 - reductionRate) を返す。
+        /// 無効時はこのメソッドが呼ばれる想定ではないが、呼ばれた場合は rawDamage をそのまま返す。
+        /// </remarks>
+        public float ProcessGaugeDamage(float rawDamage)
+        {
+            return rawDamage * (1f - _damageReductionRate);
+        }
+
+        /// <inheritdoc/>
+        public void SetActive(bool active) => _isActive = active;
+    }
+}

--- a/Assets/Scripts/Core/Enemy/BarrierController.cs.meta
+++ b/Assets/Scripts/Core/Enemy/BarrierController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a969eb88586cb684c940001ea1d240ec

--- a/Assets/Scripts/Core/Enemy/EnemyAttackGauge.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyAttackGauge.cs
@@ -1,0 +1,129 @@
+// 制作者: 山内陽
+using System;
+using UnityEngine;
+using Game.Core.Events;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 敵の攻撃ゲージ管理（MonoBehaviour）。
+    /// UpdateループでゲージをTime.deltaTime分増加させ、
+    /// ApplyGaugeDamageで減算する。
+    /// EventBusへは直接発行せず、コールバック経由でEnemyControllerに委ねる。
+    /// これによりEnemyAttackGauge自体はEventBusに非依存になり、単体テストが書きやすくなる。
+    /// </summary>
+    public class EnemyAttackGauge : MonoBehaviour
+    {
+        private string _enemyId;
+        private float _maxGauge;
+        private float _gaugeIncreaseRate;
+        private float _currentGauge;
+        private bool _isActive;
+        private IBarrier _barrier;
+
+        /// <summary>0.0〜1.0 の正規化ゲージ量（UI用）</summary>
+        public float Ratio => _maxGauge > 0f ? _currentGauge / _maxGauge : 0f;
+
+        /// <summary>現在のゲージ量（生値）</summary>
+        public float CurrentGauge => _currentGauge;
+
+        /// <summary>最大ゲージ量（生値）</summary>
+        public float MaxGauge => _maxGauge;
+
+        /// <summary>
+        /// ゲージがMAX（_maxGauge）に到達した際に発火するコールバック。
+        /// EnemyControllerが攻撃行動＆リセット処理を行う。
+        /// </summary>
+        public Action OnGaugeMaxReached;
+
+        /// <summary>
+        /// ApplyGaugeDamageによりゲージが0以下になった際に発火するコールバック。
+        /// EnemyControllerがダウン遷移を行う。
+        /// </summary>
+        public Action OnGaugeBroken;
+
+        /// <summary>
+        /// ゲージ量が変化した際に発火するコールバック（UI用EventBus発行はEnemyControllerが行う）。
+        /// 引数: currentGauge, maxGauge
+        /// </summary>
+        public Action<float, float> OnGaugeChanged;
+
+        /// <summary>
+        /// 初期化。EnemyControllerのAwakeまたはInitializeから呼ぶ。
+        /// </summary>
+        /// <param name="enemyId">識別ID</param>
+        /// <param name="maxGauge">最大ゲージ量</param>
+        /// <param name="gaugeIncreaseRate">毎秒の自然増加量</param>
+        /// <param name="barrier">適用するバリア実装（nullなら軽減なし）</param>
+        public void Initialize(string enemyId, float maxGauge, float gaugeIncreaseRate, IBarrier barrier = null)
+        {
+            _enemyId = enemyId;
+            _maxGauge = maxGauge;
+            _gaugeIncreaseRate = gaugeIncreaseRate;
+            _currentGauge = 0f;
+            _barrier = barrier;
+            _isActive = true;
+        }
+
+        /// <summary>
+        /// ゲージの増加・MAXチェックを一時停止/再開する。
+        /// ダウン中は停止、復帰後に再開する。
+        /// </summary>
+        /// <param name="active">true: 動作中, false: 停止</param>
+        public void SetActive(bool active) => _isActive = active;
+
+        private void Update()
+        {
+            if (!_isActive) return;
+
+            _currentGauge += _gaugeIncreaseRate * Time.deltaTime;
+
+            if (_currentGauge >= _maxGauge)
+            {
+                _currentGauge = _maxGauge;
+                // MAX到達はコールバック経由でControllerへ通知。Update内で複数回発火しないようにSetActive(false)をControllerが行う。
+                _isActive = false;
+                OnGaugeChanged?.Invoke(_currentGauge, _maxGauge);
+                OnGaugeMaxReached?.Invoke();
+                return;
+            }
+
+            OnGaugeChanged?.Invoke(_currentGauge, _maxGauge);
+        }
+
+        /// <summary>
+        /// ゲージダメージを適用する。バリアが有効なら軽減後の値を使う。
+        /// ゲージが0以下になった場合はOnGaugeBrokenを発火する。
+        /// </summary>
+        /// <param name="rawDamage">加工前のゲージダメージ量</param>
+        public void ApplyGaugeDamage(float rawDamage)
+        {
+            if (!_isActive) return;
+
+            // バリアが有効ならProcessGaugeDamageで軽減後の値を取得
+            float actualDamage = (_barrier != null && _barrier.IsActive)
+                ? _barrier.ProcessGaugeDamage(rawDamage)
+                : rawDamage;
+
+            _currentGauge -= actualDamage;
+            _currentGauge = Mathf.Max(0f, _currentGauge);
+
+            OnGaugeChanged?.Invoke(_currentGauge, _maxGauge);
+
+            if (_currentGauge <= 0f)
+            {
+                _isActive = false;
+                OnGaugeBroken?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// ゲージを0にリセットする。ダウン後の復帰時に使用。
+        /// </summary>
+        public void ResetGauge()
+        {
+            _currentGauge = 0f;
+            OnGaugeChanged?.Invoke(_currentGauge, _maxGauge);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/EnemyAttackGauge.cs.meta
+++ b/Assets/Scripts/Core/Enemy/EnemyAttackGauge.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c3e431e464f0e148ab2cc43c18642f1

--- a/Assets/Scripts/Core/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyController.cs
@@ -1,0 +1,207 @@
+// 制作者: 山内陽
+using UnityEngine;
+using System.Collections;
+using Game.Core.Events;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 敵の全コンポーネントを統括するコントローラ。
+    /// 責務:
+    ///   入力: EventBusの EnemyHitBatchEvent を受信し、EnemyIdで自分宛かフィルタリング
+    ///   変更: 現在の状態（EnemyStateManager）に応じてダメージをゲージ/HPへルーティング
+    ///   出力: EventBus へ各種イベントを発行（EnemyGaugeChangedEvent, EnemyHealthChangedEvent,
+    ///         EnemyGaugeBrokenEvent, EnemyDownStartedEvent, EnemyDefeatedEvent, EnemyAttackFiredEvent）
+    /// </summary>
+    [RequireComponent(typeof(EnemyAttackGauge))]
+    [RequireComponent(typeof(BarrierController))]
+    public class EnemyController : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("この敵に適用するEnemyDefinition。実行時にInitialize(def)で差し替えも可能。")]
+        private EnemyDefinition _definition;
+
+        private EnemyAttackGauge _attackGauge;
+        private EnemyHealth _health;
+        private EnemyStateManager _stateManager;
+        private BarrierController _barrier;
+        private Coroutine _downTimerCoroutine;
+
+        private void Awake()
+        {
+            // RequireComponentで必ず存在するためnullチェック不要
+            _attackGauge = GetComponent<EnemyAttackGauge>();
+            _barrier = GetComponent<BarrierController>();
+
+            if (_definition != null)
+            {
+                Initialize(_definition);
+            }
+        }
+
+        /// <summary>
+        /// EnemyDefinitionで全コンポーネントを初期化する。
+        /// Awake後の動的生成（スポーン）でも呼び出せる。
+        /// </summary>
+        /// <param name="def">適用するEnemyDefinition</param>
+        public void Initialize(EnemyDefinition def)
+        {
+            _definition = def;
+
+            // バリア初期化
+            _barrier.Initialize(def.HasBarrier, def.BarrierDamageReduction);
+
+            // 状態管理初期化
+            _stateManager = new EnemyStateManager();
+
+            // HP管理初期化
+            _health = new EnemyHealth();
+            _health.Initialize(def.EnemyId, def.MaxHp);
+            _health.OnHealthChanged = (current, max) =>
+                EventBus.Publish(new EnemyHealthChangedEvent(def.EnemyId, current, max));
+            _health.OnDefeated = HandleDefeated;
+
+            // ゲージ管理初期化
+            _attackGauge.Initialize(def.EnemyId, def.MaxGauge, def.GaugeIncreaseRate, _barrier);
+            _attackGauge.OnGaugeChanged = (current, max) =>
+                EventBus.Publish(new EnemyGaugeChangedEvent(def.EnemyId, current, max));
+            _attackGauge.OnGaugeMaxReached = HandleGaugeMaxReached;
+            _attackGauge.OnGaugeBroken = HandleGaugeBroken;
+
+            // 初期HP・ゲージをUIに通知
+            EventBus.Publish(new EnemyHealthChangedEvent(def.EnemyId, def.MaxHp, def.MaxHp));
+            EventBus.Publish(new EnemyGaugeChangedEvent(def.EnemyId, 0f, def.MaxGauge));
+
+            Debug.Log($"[EnemyController] {def.EnemyId} 初期化完了。HP={def.MaxHp}, MaxGauge={def.MaxGauge}, BarrierActive={def.HasBarrier}");
+        }
+
+        private void OnEnable()
+        {
+            EventBus.Subscribe<EnemyHitBatchEvent>(OnHitBatch);
+        }
+
+        private void OnDisable()
+        {
+            EventBus.Unsubscribe<EnemyHitBatchEvent>(OnHitBatch);
+        }
+
+        // ─────────────────────────────────────────
+        // イベント受信
+        // ─────────────────────────────────────────
+
+        /// <summary>
+        /// EnemyHitBatchEventを受信し、現在の状態に応じてダメージをルーティングする。
+        /// Normal時: ゲージダメージを適用。
+        /// Down時: 本体ダメージを適用。
+        /// Defeated時: 無視。
+        /// </summary>
+        private void OnHitBatch(EnemyHitBatchEvent ev)
+        {
+            if (_definition == null || ev.EnemyId != _definition.EnemyId) return;
+
+            switch (_stateManager.CurrentState)
+            {
+                case EnemyState.Normal:
+                    _attackGauge.ApplyGaugeDamage(ev.GaugeDamage);
+                    break;
+
+                case EnemyState.Down:
+                    _health.ApplyBodyDamage(ev.BodyDamage);
+                    break;
+
+                case EnemyState.Defeated:
+                    // 撃破済みは何もしない
+                    break;
+            }
+        }
+
+        // ─────────────────────────────────────────
+        // コールバックハンドラ
+        // ─────────────────────────────────────────
+
+        /// <summary>
+        /// ゲージが0以下になった（プレイヤーが止めた）場合の処理。
+        /// EnemyGaugeBrokenEvent発行 → Down状態へ遷移。
+        /// </summary>
+        private void HandleGaugeBroken()
+        {
+            EventBus.Publish(new EnemyGaugeBrokenEvent(_definition.EnemyId));
+            TransitionToDown();
+        }
+
+        /// <summary>
+        /// ゲージがMAXに到達した（敵が攻撃した）場合の処理。
+        /// プロト: EnemyAttackFiredEventを発行してログ出力のみ。
+        /// Phase2以降でプレイヤーへのダメージを購読側で実装する。
+        /// </summary>
+        private void HandleGaugeMaxReached()
+        {
+            Debug.Log($"[EnemyController] {_definition.EnemyId} が攻撃した！（Phase2以降でプレイヤーダメージ実装）");
+            EventBus.Publish(new EnemyAttackFiredEvent(_definition.EnemyId));
+
+            // ゲージをリセットして自然増加を再開
+            _attackGauge.ResetGauge();
+            _attackGauge.SetActive(true);
+        }
+
+        /// <summary>
+        /// HP0到達時の処理。撃破状態へ遷移し、EnemyDefeatedEventを発行する。
+        /// </summary>
+        private void HandleDefeated()
+        {
+            if (_downTimerCoroutine != null)
+            {
+                StopCoroutine(_downTimerCoroutine);
+                _downTimerCoroutine = null;
+            }
+
+            _stateManager.TransitionTo(EnemyState.Defeated);
+            _attackGauge.SetActive(false);
+            _barrier.SetActive(false);
+
+            EventBus.Publish(new EnemyDefeatedEvent(_definition.EnemyId));
+            Debug.Log($"[EnemyController] {_definition.EnemyId} 撃破！");
+        }
+
+        // ─────────────────────────────────────────
+        // 状態遷移
+        // ─────────────────────────────────────────
+
+        /// <summary>
+        /// Down状態へ遷移する。ゲージとバリアを停止し、ダウンタイマーを開始する。
+        /// </summary>
+        private void TransitionToDown()
+        {
+            _stateManager.TransitionTo(EnemyState.Down);
+            _attackGauge.SetActive(false);
+            _barrier.SetActive(false);
+
+            EventBus.Publish(new EnemyDownStartedEvent(_definition.EnemyId, _definition.DownDuration));
+
+            // 既存タイマーがあれば停止してから再スタート
+            if (_downTimerCoroutine != null) StopCoroutine(_downTimerCoroutine);
+            _downTimerCoroutine = StartCoroutine(DownTimerRoutine(_definition.DownDuration));
+        }
+
+        /// <summary>
+        /// DownDuration秒後にNormalへ自動復帰するコルーチン。
+        /// </summary>
+        private IEnumerator DownTimerRoutine(float duration)
+        {
+            yield return new WaitForSeconds(duration);
+
+            // 撃破されていなければNormalへ復帰
+            if (_stateManager.CurrentState == EnemyState.Down)
+            {
+                _stateManager.TransitionTo(EnemyState.Normal);
+                _attackGauge.ResetGauge();
+                _attackGauge.SetActive(true);
+                _barrier.SetActive(_definition.HasBarrier);
+
+                Debug.Log($"[EnemyController] {_definition.EnemyId} ダウン復帰。ゲージリセット。");
+            }
+
+            _downTimerCoroutine = null;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/EnemyController.cs.meta
+++ b/Assets/Scripts/Core/Enemy/EnemyController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 032a47519f0c83f4b887eec623df58d5

--- a/Assets/Scripts/Core/Enemy/EnemyDefinition.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyDefinition.cs
@@ -1,0 +1,38 @@
+// 制作者: 山内陽
+using UnityEngine;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 敵の性能定義。ScriptableObjectで管理することでコード変更なしにバリエーション量産が可能。
+    /// 各フィールドの意味・単位はインラインコメントを参照。
+    /// </summary>
+    [CreateAssetMenu(fileName = "NewEnemyDefinition", menuName = "Game/Enemy/EnemyDefinition")]
+    public class EnemyDefinition : ScriptableObject
+    {
+        [Header("識別")]
+        [Tooltip("ゲームシーン内でユニークな文字列。EventBusのフィルタリングに使用。")]
+        public string EnemyId = "Enemy_01";
+
+        [Header("攻撃ゲージ")]
+        [Tooltip("ゲージの最大値。この値に到達すると攻撃行動を取る。")]
+        public float MaxGauge = 100f;
+        [Tooltip("毎秒の自然増加量（Time.deltaTime乗算）。小さいほどプレイヤーに余裕が生まれる。")]
+        public float GaugeIncreaseRate = 10f;
+
+        [Header("本体HP")]
+        [Tooltip("ダウン中にのみ削れるHP。")]
+        public float MaxHp = 300f;
+
+        [Header("ダウン挙動")]
+        [Tooltip("ダウン持続時間[秒]。経過後にNormal状態へ復帰する。")]
+        public float DownDuration = 5f;
+
+        [Header("バリア")]
+        [Tooltip("バリアあり/なし。なしの場合BarrierControllerは無効状態で初期化される。")]
+        public bool HasBarrier = false;
+        [Tooltip("バリア有効時のゲージダメージ軽減割合。0=軽減なし, 1=完全無効。将来は属性ごとに持つ予定。")]
+        [Range(0f, 1f)]
+        public float BarrierDamageReduction = 0.5f;
+    }
+}

--- a/Assets/Scripts/Core/Enemy/EnemyDefinition.cs.meta
+++ b/Assets/Scripts/Core/Enemy/EnemyDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c359e2404c41384c91cd27762a269b0

--- a/Assets/Scripts/Core/Enemy/EnemyHealth.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyHealth.cs
@@ -1,0 +1,69 @@
+// 制作者: 山内陽
+using System;
+using UnityEngine;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 敵の本体HP管理（純粋クラス）。
+    /// ダメージ適用・撃破判定・HP変化通知の責務のみを持つ。
+    /// 「ダウン中のみダメージを受ける」制御はEnemyControllerが呼び出し前に判断する。
+    /// </summary>
+    public class EnemyHealth
+    {
+        private string _enemyId;
+        private float _maxHp;
+        private float _currentHp;
+
+        /// <summary>現在のHP（0〜MaxHp）</summary>
+        public float CurrentHp => _currentHp;
+
+        /// <summary>最大HP</summary>
+        public float MaxHp => _maxHp;
+
+        /// <summary>HPが0以下かどうか</summary>
+        public bool IsDefeated => _currentHp <= 0f;
+
+        /// <summary>
+        /// HP変化時に発火するコールバック。
+        /// 引数: currentHp, maxHp
+        /// </summary>
+        public Action<float, float> OnHealthChanged;
+
+        /// <summary>HP0到達時に発火するコールバック。1度だけ呼ばれる。</summary>
+        public Action OnDefeated;
+
+        /// <summary>
+        /// 初期化。インスタンス生成後に必ず呼ぶ。
+        /// </summary>
+        /// <param name="enemyId">EnemyDefinitionで定義したEnemyId</param>
+        /// <param name="maxHp">最大HP</param>
+        public void Initialize(string enemyId, float maxHp)
+        {
+            _enemyId = enemyId;
+            _maxHp = maxHp;
+            _currentHp = maxHp;
+        }
+
+        /// <summary>
+        /// 本体ダメージを適用する。
+        /// 既に撃破済みの場合は何もしない。
+        /// HP0到達時にOnDefeatedを1度だけ発火する。
+        /// </summary>
+        /// <param name="damage">適用するダメージ量（正値）</param>
+        public void ApplyBodyDamage(float damage)
+        {
+            if (IsDefeated) return;
+
+            _currentHp -= damage;
+            _currentHp = Mathf.Max(0f, _currentHp);
+
+            OnHealthChanged?.Invoke(_currentHp, _maxHp);
+
+            if (_currentHp <= 0f)
+            {
+                OnDefeated?.Invoke();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/EnemyHealth.cs.meta
+++ b/Assets/Scripts/Core/Enemy/EnemyHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8339a3df8fd37c0439bc51d76461a544

--- a/Assets/Scripts/Core/Enemy/EnemyStateManager.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyStateManager.cs
@@ -1,0 +1,64 @@
+// 制作者: 山内陽
+using System;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 敵の状態種別。
+    /// 新しい状態（Enraged等）を追加する際はここに追記し、EnemyControllerのswitch文に対応ケースを足す。
+    /// </summary>
+    public enum EnemyState
+    {
+        /// <summary>通常：ゲージが自然増加し、ゲージダメージを受け付ける</summary>
+        Normal,
+        /// <summary>ダウン：本体HPへのダメージを受け付ける。ゲージは停止。</summary>
+        Down,
+        /// <summary>撃破済み：一切の状態遷移・ダメージを受け付けない</summary>
+        Defeated,
+    }
+
+    /// <summary>
+    /// 敵の状態遷移を管理する純粋クラス（MonoBehaviour非依存）。
+    /// 遷移の正当性チェック（Defeatedからの遷移防止等）をここに集約し、
+    /// EnemyControllerが複数のコンポーネントを誤った順序で呼ぶことを防ぐ。
+    /// </summary>
+    public class EnemyStateManager
+    {
+        /// <summary>現在の状態</summary>
+        public EnemyState CurrentState { get; private set; } = EnemyState.Normal;
+
+        /// <summary>状態変化時に発火するコールバック。引数は新しい状態。</summary>
+        public event Action<EnemyState> OnStateChanged;
+
+        /// <summary>ダウン中かどうか</summary>
+        public bool IsDown => CurrentState == EnemyState.Down;
+
+        /// <summary>撃破済みかどうか</summary>
+        public bool IsDefeated => CurrentState == EnemyState.Defeated;
+
+        /// <summary>ゲージダメージを受け付けられるか（Normal状態のみ）</summary>
+        public bool CanReceiveGaugeDamage => CurrentState == EnemyState.Normal;
+
+        /// <summary>本体ダメージを受け付けられるか（Down状態のみ）</summary>
+        public bool CanReceiveBodyDamage => CurrentState == EnemyState.Down;
+
+        /// <summary>
+        /// 状態を遷移させる。
+        /// Defeated後の遷移、および同一状態への遷移は無視する。
+        /// </summary>
+        /// <param name="newState">遷移先の状態</param>
+        public void TransitionTo(EnemyState newState)
+        {
+            // 撃破済みからは一切遷移しない（最終状態）
+            if (CurrentState == EnemyState.Defeated) return;
+            // 同じ状態への遷移は無視
+            if (CurrentState == newState) return;
+
+            var prev = CurrentState;
+            CurrentState = newState;
+            OnStateChanged?.Invoke(newState);
+
+            UnityEngine.Debug.Log($"[EnemyStateManager] {prev} → {newState}");
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/EnemyStateManager.cs.meta
+++ b/Assets/Scripts/Core/Enemy/EnemyStateManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 332ea97ffddfb3b4db56c95d8a8f56c5

--- a/Assets/Scripts/Core/Enemy/IBarrier.cs
+++ b/Assets/Scripts/Core/Enemy/IBarrier.cs
@@ -1,0 +1,30 @@
+// 制作者: 山内陽
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// バリア機能の抽象化インターフェース。
+    /// プロト: BarrierController（割合軽減）のみ実装。
+    /// 将来的に属性対応バリアや多層バリアへ差し替え可能にするための契約。
+    /// </summary>
+    public interface IBarrier
+    {
+        /// <summary>現在バリアが有効かどうか</summary>
+        bool IsActive { get; }
+
+        /// <summary>
+        /// 受けたゲージダメージを処理し、実際に通すダメージ量を返す。
+        /// バリアが有効なら軽減、無効ならそのまま通す。
+        /// </summary>
+        /// <param name="rawDamage">加工前のゲージダメージ量</param>
+        /// <returns>実際に適用するゲージダメージ量</returns>
+        float ProcessGaugeDamage(float rawDamage);
+
+        /// <summary>
+        /// バリアの有効/無効を切り替える。
+        /// ダウン中は無効化、復帰後に再有効化する用途を想定。
+        /// </summary>
+        /// <param name="active">true: 有効, false: 無効</param>
+        void SetActive(bool active);
+    }
+}

--- a/Assets/Scripts/Core/Enemy/IBarrier.cs.meta
+++ b/Assets/Scripts/Core/Enemy/IBarrier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d63017848eb908a479da3a5038ceccd8

--- a/Assets/Scripts/Core/Events/GameEvents.cs
+++ b/Assets/Scripts/Core/Events/GameEvents.cs
@@ -80,4 +80,75 @@ namespace Game.Core.Events
             TiltDirection = tiltDirection;
         }
     }
+
+    /// <summary>
+    /// 敵の攻撃ゲージ量変化通知。
+    /// EnemyAttackGaugeが増減のたびに発行する。
+    /// UIはRatioのみ使用することもでき、将来的な詳細表示にはCurrentGauge/MaxGaugeを利用する。
+    /// </summary>
+    public readonly struct EnemyGaugeChangedEvent
+    {
+        public readonly string EnemyId;
+        public readonly float CurrentGauge;
+        public readonly float MaxGauge;
+        /// <summary>0.0〜1.0 の正規化ゲージ量（UI用）</summary>
+        public readonly float Ratio;
+
+        public EnemyGaugeChangedEvent(string enemyId, float currentGauge, float maxGauge)
+        {
+            EnemyId = enemyId;
+            CurrentGauge = currentGauge;
+            MaxGauge = maxGauge;
+            Ratio = maxGauge > 0f ? currentGauge / maxGauge : 0f;
+        }
+    }
+
+    /// <summary>
+    /// 敵の本体HP変化通知。
+    /// EnemyHealthが変化するたびに発行する。
+    /// </summary>
+    public readonly struct EnemyHealthChangedEvent
+    {
+        public readonly string EnemyId;
+        public readonly float CurrentHp;
+        public readonly float MaxHp;
+        /// <summary>0.0〜1.0 の正規化HP（UI用）</summary>
+        public readonly float Ratio;
+
+        public EnemyHealthChangedEvent(string enemyId, float currentHp, float maxHp)
+        {
+            EnemyId = enemyId;
+            CurrentHp = currentHp;
+            MaxHp = maxHp;
+            Ratio = maxHp > 0f ? currentHp / maxHp : 0f;
+        }
+    }
+
+    /// <summary>
+    /// 敵撃破通知。HP0到達時にEnemyHealthが発行する。
+    /// </summary>
+    public readonly struct EnemyDefeatedEvent
+    {
+        public readonly string EnemyId;
+
+        public EnemyDefeatedEvent(string enemyId)
+        {
+            EnemyId = enemyId;
+        }
+    }
+
+    /// <summary>
+    /// 敵のゲージMAX到達による攻撃発動通知。
+    /// Phase2以降でプレイヤーへのダメージ処理を受け取るために用意する。
+    /// </summary>
+    public readonly struct EnemyAttackFiredEvent
+    {
+        public readonly string EnemyId;
+
+        public EnemyAttackFiredEvent(string enemyId)
+        {
+            EnemyId = enemyId;
+            }
+    }
 }
+

--- a/Assets/Scripts/DebugTools/DebugEventEmitter.cs
+++ b/Assets/Scripts/DebugTools/DebugEventEmitter.cs
@@ -1,11 +1,13 @@
 // 制作者: 山内陽
 using UnityEngine;
 using Game.Core.Events;
+using Game.Core.Enemy;
 
 namespace Game.DebugTools
 {
     /// <summary>
     /// UIの単体検証を行うため、Inspectorから各種イベントを手動発行するデバッグ用スクリプト。
+    /// EnemyControllerへの参照を持てる場合は直接操作も可能。
     /// </summary>
     public class DebugEventEmitter : MonoBehaviour
     {
@@ -64,5 +66,43 @@ namespace Game.DebugTools
             EventBus.Publish(new StageTiltStartedEvent(Vector3.right));
             Debug.Log("[Debug] Fire StageTiltStartedEvent");
         }
+
+        [ContextMenu("Fire Enemy Defeated Event")]
+        public void FireEnemyDefeated()
+        {
+            EventBus.Publish(new EnemyDefeatedEvent(enemyId));
+            Debug.Log("[Debug] Fire EnemyDefeatedEvent");
+        }
+
+        [ContextMenu("Fire Enemy Attack Fired Event")]
+        public void FireEnemyAttackFired()
+        {
+            EventBus.Publish(new EnemyAttackFiredEvent(enemyId));
+            Debug.Log("[Debug] Fire EnemyAttackFiredEvent");
+        }
+
+        /// <summary>
+        /// EnemyHitBatchEventを大量のゲージダメージ（999）で発行し、
+        /// EnemyControllerのゲージを即破壊してダウン遷移を強制する。
+        /// EnemyControllerが存在するシーンでのみ有効。
+        /// </summary>
+        [ContextMenu("DEBUG: Force Enemy Down (Large Gauge Damage)")]
+        public void ForceEnemyDown()
+        {
+            EventBus.Publish(new EnemyHitBatchEvent(enemyId, 1, 999f, 0f, transform.position));
+            Debug.Log("[Debug] Force Enemy Down: EnemyHitBatchEvent with GaugeDamage=999");
+        }
+
+        /// <summary>
+        /// EnemyHitBatchEventを大量の本体ダメージ（999）で発行し、
+        /// ダウン中の敵を即撃破する。ダウン状態でのみ有効。
+        /// </summary>
+        [ContextMenu("DEBUG: Force Enemy Defeat (Large Body Damage)")]
+        public void ForceEnemyDefeat()
+        {
+            EventBus.Publish(new EnemyHitBatchEvent(enemyId, 1, 0f, 999f, transform.position));
+            Debug.Log("[Debug] Force Enemy Defeat: EnemyHitBatchEvent with BodyDamage=999");
+        }
     }
 }
+

--- a/Assets/Scripts/Presentation/UI/EnemyGaugeView.cs
+++ b/Assets/Scripts/Presentation/UI/EnemyGaugeView.cs
@@ -7,19 +7,28 @@ using System.Collections;
 namespace Game.Presentation.UI
 {
     /// <summary>
-    /// 敵の頭上に表示するゲージUI。
-    /// ゲージダメージの適用やダウン状態の表示を行う。
+    /// 敵の攻撃ゲージをUIに表示するコンポーネント。
+    /// EnemyAttackGaugeが発行するEnemyGaugeChangedEventを購読し、
+    /// Sliderの値をそのまま反映する（自前でゲージ計算を行わない）。
     /// </summary>
     public class EnemyGaugeView : MonoBehaviour
     {
-        [SerializeField] private string _targetEnemyId;
+        [SerializeField]
+        [Tooltip("表示対象の敵のEnemyId。EnemyDefinition.EnemyIdと一致させる。")]
+        private string _targetEnemyId;
+
         [SerializeField] private Slider _gaugeSlider;
         [SerializeField] private Image _fillImage;
+
+        [Header("通常/ダウン状態のFill色")]
         [SerializeField] private Color _normalColor = Color.yellow;
-        [SerializeField] private Color _downColor = Color.red;
+        [SerializeField] private Color _downColor   = Color.red;
 
-        private float _currentGauge = 1.0f; // 1.0 = Full
-
+        /// <summary>
+        /// 動的生成時にEnemyIdを外部から設定する。
+        /// Inspector設定の場合は呼び出し不要。
+        /// </summary>
+        /// <param name="enemyId">EnemyDefinition.EnemyId</param>
         public void Initialize(string enemyId)
         {
             _targetEnemyId = enemyId;
@@ -27,28 +36,35 @@ namespace Game.Presentation.UI
 
         private void OnEnable()
         {
-            EventBus.Subscribe<EnemyHitBatchEvent>(OnHitBatch);
+            EventBus.Subscribe<EnemyGaugeChangedEvent>(OnGaugeChanged);
             EventBus.Subscribe<EnemyDownStartedEvent>(OnDownStarted);
+            EventBus.Subscribe<EnemyGaugeBrokenEvent>(OnGaugeBroken);
+            EventBus.Subscribe<EnemyDefeatedEvent>(OnDefeated);
         }
 
         private void OnDisable()
         {
-            EventBus.Unsubscribe<EnemyHitBatchEvent>(OnHitBatch);
+            EventBus.Unsubscribe<EnemyGaugeChangedEvent>(OnGaugeChanged);
             EventBus.Unsubscribe<EnemyDownStartedEvent>(OnDownStarted);
+            EventBus.Unsubscribe<EnemyGaugeBrokenEvent>(OnGaugeBroken);
+            EventBus.Unsubscribe<EnemyDefeatedEvent>(OnDefeated);
         }
 
-        private void OnHitBatch(EnemyHitBatchEvent ev)
+        private void OnGaugeChanged(EnemyGaugeChangedEvent ev)
         {
             if (ev.EnemyId != _targetEnemyId) return;
 
-            // 仮のゲージ減算（本来は敵側のロジック管理だが、プロトとして見た目だけ反映）
-            _currentGauge -= ev.GaugeDamage * 0.1f; 
-            _currentGauge = Mathf.Clamp01(_currentGauge);
-            
             if (_gaugeSlider != null)
-            {
-                _gaugeSlider.value = _currentGauge;
-            }
+                _gaugeSlider.value = ev.Ratio;
+        }
+
+        private void OnGaugeBroken(EnemyGaugeBrokenEvent ev)
+        {
+            if (ev.EnemyId != _targetEnemyId) return;
+
+            // ゲージ破壊時はSliderを0にリセット
+            if (_gaugeSlider != null)
+                _gaugeSlider.value = 0f;
         }
 
         private void OnDownStarted(EnemyDownStartedEvent ev)
@@ -56,20 +72,25 @@ namespace Game.Presentation.UI
             if (ev.EnemyId != _targetEnemyId) return;
 
             if (_fillImage != null)
-            {
                 _fillImage.color = _downColor;
-            }
-            
-            StartCoroutine(ResetGaugeAfterDown(ev.Duration));
+
+            StartCoroutine(ResetColorAfterDown(ev.Duration));
         }
 
-        private IEnumerator ResetGaugeAfterDown(float duration)
+        private void OnDefeated(EnemyDefeatedEvent ev)
+        {
+            if (ev.EnemyId != _targetEnemyId) return;
+            gameObject.SetActive(false);
+        }
+
+        private IEnumerator ResetColorAfterDown(float duration)
         {
             yield return new WaitForSeconds(duration);
-            
-            _currentGauge = 1.0f;
-            if (_gaugeSlider != null) _gaugeSlider.value = _currentGauge;
-            if (_fillImage != null) _fillImage.color = _normalColor;
+
+            // 撃破されていなければ色を通常に戻す（非表示なら何もしない）
+            if (gameObject.activeSelf && _fillImage != null)
+                _fillImage.color = _normalColor;
         }
     }
 }
+

--- a/Assets/Scripts/Presentation/UI/EnemyHealthBar.cs
+++ b/Assets/Scripts/Presentation/UI/EnemyHealthBar.cs
@@ -1,0 +1,72 @@
+// 制作者: 山内陽
+using UnityEngine;
+using UnityEngine.UI;
+using Game.Core.Events;
+
+namespace Game.Presentation.UI
+{
+    /// <summary>
+    /// 敵の本体HPバーを表示するUIコンポーネント。
+    /// EnemyHealthChangedEvent / EnemyDefeatedEvent を購読して表示を更新する。
+    /// EnemyGaugeView と同一Canvasに配置し、同一のtargetEnemyIdを設定して使う。
+    /// </summary>
+    public class EnemyHealthBar : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("表示対象の敵のEnemyId。EnemyDefinition.EnemyIdと一致させる。")]
+        private string _targetEnemyId;
+
+        [SerializeField] private Slider _hpSlider;
+        [SerializeField] private Image _hpFillImage;
+
+        [Header("HP割合によるFill色変化")]
+        [SerializeField] private Color _highHpColor = new Color(0.2f, 0.8f, 0.2f); // 緑
+        [SerializeField] private Color _midHpColor  = new Color(0.9f, 0.7f, 0.1f); // 黄
+        [SerializeField] private Color _lowHpColor  = new Color(0.9f, 0.2f, 0.2f); // 赤
+
+        /// <summary>
+        /// 動的生成時にEnemyIdを外部から設定する。
+        /// Inspector設定の場合はこのメソッド呼び出しは不要。
+        /// </summary>
+        /// <param name="enemyId">EnemyDefinition.EnemyId</param>
+        public void Initialize(string enemyId)
+        {
+            _targetEnemyId = enemyId;
+        }
+
+        private void OnEnable()
+        {
+            EventBus.Subscribe<EnemyHealthChangedEvent>(OnHealthChanged);
+            EventBus.Subscribe<EnemyDefeatedEvent>(OnDefeated);
+        }
+
+        private void OnDisable()
+        {
+            EventBus.Unsubscribe<EnemyHealthChangedEvent>(OnHealthChanged);
+            EventBus.Unsubscribe<EnemyDefeatedEvent>(OnDefeated);
+        }
+
+        private void OnHealthChanged(EnemyHealthChangedEvent ev)
+        {
+            if (ev.EnemyId != _targetEnemyId) return;
+
+            if (_hpSlider != null)
+                _hpSlider.value = ev.Ratio;
+
+            // HP割合に応じてFill色をグラデーション。0.5以上は高→中、0.5未満は中→低でLerp。
+            if (_hpFillImage != null)
+            {
+                _hpFillImage.color = ev.Ratio >= 0.5f
+                    ? Color.Lerp(_midHpColor, _highHpColor, (ev.Ratio - 0.5f) * 2f)
+                    : Color.Lerp(_lowHpColor, _midHpColor, ev.Ratio * 2f);
+            }
+        }
+
+        private void OnDefeated(EnemyDefeatedEvent ev)
+        {
+            if (ev.EnemyId != _targetEnemyId) return;
+            // 撃破時はHPバーを非表示にする（Presenterとして表示制御のみ担う）
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/UI/EnemyHealthBar.cs.meta
+++ b/Assets/Scripts/Presentation/UI/EnemyHealthBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a0a4cb610e4b344ba7ddf7abfb949b1

--- a/Assets/Scripts/Presentation/UI/HitPopupPresenter.cs
+++ b/Assets/Scripts/Presentation/UI/HitPopupPresenter.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 namespace Game.Presentation.UI
 {
     /// <summary>
-    /// 大量ヒットやダメージのポップアップ表示を制御する。
+    /// 大量ヒットや撃破のポップアップ表示を制御する。
     /// （プロトタイプでは簡易的にCanvas上のTextとして生成）
     /// </summary>
     public class HitPopupPresenter : MonoBehaviour
@@ -17,11 +17,13 @@ namespace Game.Presentation.UI
         private void OnEnable()
         {
             EventBus.Subscribe<EnemyHitBatchEvent>(OnHitBatch);
+            EventBus.Subscribe<EnemyDefeatedEvent>(OnDefeated);
         }
 
         private void OnDisable()
         {
             EventBus.Unsubscribe<EnemyHitBatchEvent>(OnHitBatch);
+            EventBus.Unsubscribe<EnemyDefeatedEvent>(OnDefeated);
         }
 
         private void OnHitBatch(EnemyHitBatchEvent ev)
@@ -30,17 +32,35 @@ namespace Game.Presentation.UI
 
             // TODO: 本来はPoolServiceを使う
             var popupObj = Instantiate(_popupPrefab, _popupContainer);
-            
-            // 適当なオフセット位置
             popupObj.transform.position = ev.HitPosition + Vector3.up * Random.Range(1.0f, 2.0f);
-            
+
             var textComp = popupObj.GetComponentInChildren<Text>();
             if (textComp != null)
             {
                 textComp.text = $"{ev.HitCount} Hits!\n{ev.BodyDamage:F0} Dmg";
             }
 
-            Destroy(popupObj, 1.5f); // 仮の寿命
+            Destroy(popupObj, 1.5f);
+        }
+
+        private void OnDefeated(EnemyDefeatedEvent ev)
+        {
+            if (_popupPrefab == null || _popupContainer == null) return;
+
+            var popupObj = Instantiate(_popupPrefab, _popupContainer);
+
+            // TODO: 撃破した敵のWorldPosition取得にはEnemyDefeatedEventへVector3を追加するか
+            //       EnemyController側でWorldPositionを含めた発行に変更する（Phase2で対応）
+            popupObj.transform.position = Vector3.zero + Vector3.up * 2f;
+
+            var textComp = popupObj.GetComponentInChildren<Text>();
+            if (textComp != null)
+            {
+                textComp.text = $"DEFEATED!\n{ev.EnemyId}";
+            }
+
+            Destroy(popupObj, 2.5f);
         }
     }
 }
+


### PR DESCRIPTION
﻿## 概要
敵システムの基盤実装とUIとの統合を行う。Issue #210（敵接続とゲージ減少の統合）および #211（本体ダメージと撃破の統合）のプロトタイプ完成を目的とする。

EventBus経由の疎結合設計を採用し、EnemyControllerが各コンポーネントを統括してイベントを発行、UIが購読する形で接続した。

## 変更内容
- Core/Enemy/ 配下に敵ロジック層を新規実装（7ファイル）
  - EnemyDefinition (ScriptableObject): 敵パラメータのデータ化
  - EnemyController (MonoBehaviour): ゲージ・HP・状態・バリアを統括する司令塔
  - EnemyAttackGauge (MonoBehaviour): 時間でゲージが増加、ダメージで減少するロジック
  - EnemyHealth (純粋クラス): HPの増減・撃破判定（EventBus非依存）
  - EnemyStateManager (純粋クラス): Normal/Down/Defeated の状態遷移
  - BarrierController (MonoBehaviour): IBarrier実装、ダメージ軽減
  - IBarrier: 差し替え可能なバリア抽象インターフェース
- GameEvents.cs に敵関連イベント4型を追加（EnemyGaugeChangedEvent, EnemyHealthChangedEvent, EnemyDefeatedEvent, EnemyAttackFiredEvent）
- EnemyGaugeView.cs をリファクタリング: 仮計算を撤廃し EnemyGaugeChangedEvent 購読へ切替
- EnemyHealthBar.cs を新規作成: EnemyHealthChangedEvent を購読し3段階色変化（緑→黄→赤）
- HitPopupPresenter.cs に EnemyDefeatedEvent 購読を追加しDEFEATED! ポップアップ表示
- DebugEventEmitter.cs に新イベント対応・強制ダウン/撃破機能を追加
- Assets/Game/Enemy/Enemy_01_Definition.asset: デフォルトSO（MCP経由でシーンに配置済み）
- Proto_G_UIDebug.unity: EnemyController・EnemyHealthBar UIを配置・全参照を接続済み

## 確認項目 (セルフチェック)

### 💻 実装・品質
- [x] **命名規則**: STYLE_GUIDE.md に従った命名（Suffix等）になっているか
- [x] **整形**: dotnet format が通り、.editorconfig に従っているか
- [x] **メタファイル**: 新規ファイルに .meta ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な using が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか（EnemyControllerがコールバックを一元管理）
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか（EnemyGaugeView・EnemyHealthBarはイベント購読のみ）
- [x] **依存関係**: 依存先を増やす前に GameMediator を検討したか（EventBusで代替、直接参照ゼロ）

## 関連Issue
Closes #210
Closes #211

## その他 (懸念点・共有事項)
- StandaloneInputModule の InputSystem競合エラーが既存シーンに残存するが今回の変更と無関係
- 敵の攻撃行動（EnemyAttackFiredEvent 受信後のダメージ処理）は Phase2 次タスク（#212以降）で実装予定
- バリア・属性拡張は IBarrier 実装クラスの追加のみで対応可能な設計にしてある
