### PR TITLE
chore: プロジェクト基盤の構築と初期整理

### DIFF
--- a/Assets/Scenes/Select.unity
+++ b/Assets/Scenes/Select.unity
@@ -801,8 +801,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf026e860459d0a4db54fa8235a0b621, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CreatorKousien.Battle.TurnManager
-  _maxInputCount: 3
-  _commandTimeLimit: 5
+  _maxInputCount: 1
+  _commandTimeLimit: 2
+  _visibleEnemyAction: 5
 --- !u!114 &811160245
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battle/Turn/States/CommandPhaseState.cs
+++ b/Assets/Scripts/Battle/Turn/States/CommandPhaseState.cs
@@ -64,13 +64,17 @@ namespace CreatorKousien.Battle
             // 新しい思考を始める前に、画面上の前回の予告を全て消す
             _owner.EventBus.PublishClearAllTelegraphs();
 
+            // 敵の最大予告数 - 今の保持してる手数
+            int rollEnemyActTimes = _owner.VisibleEnemyAction - _owner.EnemyActions.Count;
+
             // フェーズ開始と同時に、全てのエネミーの3手分を計算させる
             var planCommand = new EnemyActionCommand((teamPlan) =>
             {
-                _enemyPlannedActions = teamPlan;
+                _owner.AddEnemyActionTelegraph(teamPlan);
+                //_enemyPlannedActions = teamPlan;
                 UpdateTimelineUI();
                 Debug.Log($"[Command Phase] 敵チーム全体の3手を受領しました！");
-            });
+            },rollEnemyActTimes);
 
             _owner.Dispatcher.Dispatch(planCommand);
 
@@ -98,9 +102,6 @@ namespace CreatorKousien.Battle
             // 時間ゲージのカウントダウンロジック、カード選択等
             // タイムアップしているか、3手入力済みなら何もしない
             if (_isTimeUp || _playerSelectedActions.Count >= _owner.MaxInputCount) return;
-
-            // 既にタイムアップしているか、3手入力済みなら何もしない
-            if (_isTimeUp || _playerSelectedActions.Count >= 3) return;
 
             // タイマーを減算
             _currentTime -= Time.deltaTime;
@@ -194,11 +195,11 @@ namespace CreatorKousien.Battle
         /// <param name="action"></param>
         public void AddPlayerAction(ActionRuntimeData action)
         {
-            if (_playerSelectedActions.Count >= 3) return;
+            if (_playerSelectedActions.Count >= _owner.MaxInputCount) return;
 
             _playerSelectedActions.Add(action);
             UpdateTimelineUI();
-            Debug.Log($"[Command] プレイヤーのアクションを予約: {action.Type} ({_playerSelectedActions.Count}/3)");
+            Debug.Log($"[Command] プレイヤーのアクションを予約: {action.Type} ({_playerSelectedActions.Count}/{_owner.MaxInputCount})");
 
             // 3手選んだら自動で実行フェーズへ
             if (_playerSelectedActions.Count == _owner.MaxInputCount)
@@ -210,7 +211,10 @@ namespace CreatorKousien.Battle
         private void FinishPhase()
         {
             // プレイヤーと敵のアクションを交互に並べて、TurnManagerに渡す
-            List<BattleStep> steps = CreateBattleSteps(_playerSelectedActions, _enemyPlannedActions);
+            //List<BattleStep> steps = CreateBattleSteps(_playerSelectedActions, _enemyPlannedActions);
+
+            var steps = new List<BattleStep>();
+            steps.Add(new BattleStep(_playerSelectedActions[0], _owner.GetEnemyActionTelegraph()));
 
             _owner.SetActionQueue(steps);
             _owner.TransitionTo(PhaseType.Action);

--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using CreatorKousien.Core;
 using CreatorKousien.Data;
 using UnityEngine.Rendering;
+using System.Linq;
 
 namespace CreatorKousien.Battle
 {
@@ -72,7 +73,8 @@ namespace CreatorKousien.Battle
         private Queue<BattleStep> _stepQueue = new Queue<BattleStep>();
         private Queue<ActionRuntimeData> _microQueue = new Queue<ActionRuntimeData>();
         // 敵の行動のみをスタックするキュー
-        private Queue<ActionRuntimeData> _enemyActionQueue = new Queue<ActionRuntimeData>();
+        private List<ActionRuntimeData> _enemyActions = new List<ActionRuntimeData>();
+        public IReadOnlyList<ActionRuntimeData> EnemyActions =>_enemyActions;
 
         public List<ActionRuntimeData> _enemyTelegraphs = new List<ActionRuntimeData>();
 
@@ -326,7 +328,7 @@ namespace CreatorKousien.Battle
         {
             foreach (var action in data)
             {
-                _enemyActionQueue.Enqueue(action);
+                _enemyActions.Add(action);
             }
         }
 
@@ -336,7 +338,10 @@ namespace CreatorKousien.Battle
         /// <returns></returns>
         public ActionRuntimeData GetEnemyActionTelegraph()
         {
-            return _enemyActionQueue.Dequeue();
+            ActionRuntimeData action;
+            action = _enemyActions.FirstOrDefault();
+            _enemyActions.Remove(action);
+            return action;
         }
     }
 }

--- a/Assets/Scripts/Battle/Turn/TurnManager.cs
+++ b/Assets/Scripts/Battle/Turn/TurnManager.cs
@@ -35,6 +35,7 @@ namespace CreatorKousien.Battle
         [Header("コマンドフェーズの設定")]
         [SerializeField] private int _maxInputCount = 3;        // プレイヤーがコマンドフェーズで入力できる最大アクション数
         [SerializeField] private float _commandTimeLimit = 3f;  // コマンドフェーズの時間制限（秒）
+        [SerializeField] private int _visibleEnemyAction = 5;   // コマンドフェーズで視認可能な敵の行動個数
 
         /// <summary>
         /// 最大入力数
@@ -46,6 +47,10 @@ namespace CreatorKousien.Battle
         /// </summary>
         public float CommandTimeLimit => _commandTimeLimit;
 
+        /// <summary>
+        /// 敵の最大行動視認可能数
+        /// </summary>
+        public int VisibleEnemyAction => _visibleEnemyAction;
 
         /// <summary>
         /// プレイヤーがカードを使ったことを通知するイベント
@@ -66,6 +71,10 @@ namespace CreatorKousien.Battle
         // ステップ単位のキューと、そのステップ内で順番に処理するマイクロキュー
         private Queue<BattleStep> _stepQueue = new Queue<BattleStep>();
         private Queue<ActionRuntimeData> _microQueue = new Queue<ActionRuntimeData>();
+        // 敵の行動のみをスタックするキュー
+        private Queue<ActionRuntimeData> _enemyActionQueue = new Queue<ActionRuntimeData>();
+
+        public List<ActionRuntimeData> _enemyTelegraphs = new List<ActionRuntimeData>();
 
         // このステップでキャンセルされたアクターのIDのリスト
         private HashSet<int> _cancelledActorsThisStep = new HashSet<int>();
@@ -282,7 +291,6 @@ namespace CreatorKousien.Battle
             }
         }
 
-
         /// <summary>
         /// 敵がアクションを決定した後、Commandフェーズから呼び出される想定のメソッド。（デバック用なので改変しても大丈夫）
         /// </summary>
@@ -308,6 +316,27 @@ namespace CreatorKousien.Battle
                 return _commandPhase.IsSlotUsed(slot);
             }
             return false;
+        }
+
+        /// <summary>
+        /// 敵の行動予告を格納する
+        /// </summary>
+        /// <param name="data"></param>
+        public void AddEnemyActionTelegraph(List<ActionRuntimeData> data)
+        {
+            foreach (var action in data)
+            {
+                _enemyActionQueue.Enqueue(action);
+            }
+        }
+
+        /// <summary>
+        /// 敵の行動予告を取得
+        /// </summary>
+        /// <returns></returns>
+        public ActionRuntimeData GetEnemyActionTelegraph()
+        {
+            return _enemyActionQueue.Dequeue();
         }
     }
 }

--- a/Assets/Scripts/Command/Enemy/EnemyActionCommand.cs
+++ b/Assets/Scripts/Command/Enemy/EnemyActionCommand.cs
@@ -20,9 +20,12 @@ namespace CreatorKousien.Command
         // 全てのエネミーのプランをActorIDとキーにして受けとる
         public Action<List<ActionRuntimeData>> OnPlanGenerated { get; }
 
-        public EnemyActionCommand(Action<List<ActionRuntimeData>> onPlanGenerated)
+        public int RollEnemyActTimes { get; }
+
+        public EnemyActionCommand(Action<List<ActionRuntimeData>> onPlanGenerated, int rollEnemyActTimes)
         {
             OnPlanGenerated = onPlanGenerated;
+            RollEnemyActTimes = rollEnemyActTimes;
         }
     }
 }

--- a/Assets/Scripts/Core/Events/EventBus.cs
+++ b/Assets/Scripts/Core/Events/EventBus.cs
@@ -1,0 +1,60 @@
+// 制作者: 山内陽
+using System;
+using System.Collections.Generic;
+
+namespace Game.Core.Events
+{
+    /// <summary>
+    /// 軽量EventBus実装。
+    /// UIや各機能間の連携（一方向通信）に利用する。
+    /// </summary>
+    public static class EventBus
+    {
+        private static readonly Dictionary<Type, Delegate> _subscribers = new Dictionary<Type, Delegate>();
+
+        public static void Subscribe<T>(Action<T> handler) where T : struct
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var existing))
+            {
+                _subscribers[type] = Delegate.Combine(existing, handler);
+            }
+            else
+            {
+                _subscribers[type] = handler;
+            }
+        }
+
+        public static void Unsubscribe<T>(Action<T> handler) where T : struct
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var existing))
+            {
+                var newDelegate = Delegate.Remove(existing, handler);
+                if (newDelegate == null)
+                {
+                    _subscribers.Remove(type);
+                }
+                else
+                {
+                    _subscribers[type] = newDelegate;
+                }
+            }
+        }
+
+        public static void Publish<T>(T eventData) where T : struct
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var existing))
+            {
+                var handler = existing as Action<T>;
+                handler?.Invoke(eventData);
+            }
+        }
+
+        public static void ClearAll()
+        {
+            _subscribers.Clear();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Events/EventBus.cs.meta
+++ b/Assets/Scripts/Core/Events/EventBus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 411201c372f98534ea9e5ed79078fd4f

--- a/Assets/Scripts/Core/Events/GameEvents.cs
+++ b/Assets/Scripts/Core/Events/GameEvents.cs
@@ -1,0 +1,83 @@
+// 制作者: 山内陽
+using UnityEngine;
+
+namespace Game.Core.Events
+{
+    public readonly struct CollectionChangedEvent
+    {
+        public readonly int CurrentCount;
+        public readonly int Capacity;
+
+        public CollectionChangedEvent(int currentCount, int capacity)
+        {
+            CurrentCount = currentCount;
+            Capacity = capacity;
+        }
+    }
+
+    public readonly struct PayloadReleasedEvent
+    {
+        public readonly int PayloadCount;
+        public readonly float TotalPower;
+        public readonly Vector3 ReleasePosition;
+        public readonly Vector3 ReleaseDirection;
+
+        public PayloadReleasedEvent(int count, float power, Vector3 pos, Vector3 dir)
+        {
+            PayloadCount = count;
+            TotalPower = power;
+            ReleasePosition = pos;
+            ReleaseDirection = dir;
+        }
+    }
+
+    public readonly struct EnemyHitBatchEvent
+    {
+        public readonly string EnemyId;
+        public readonly int HitCount;
+        public readonly float GaugeDamage;
+        public readonly float BodyDamage;
+        public readonly Vector3 HitPosition;
+
+        public EnemyHitBatchEvent(string enemyId, int hitCount, float gaugeDamage, float bodyDamage, Vector3 pos)
+        {
+            EnemyId = enemyId;
+            HitCount = hitCount;
+            GaugeDamage = gaugeDamage;
+            BodyDamage = bodyDamage;
+            HitPosition = pos;
+        }
+    }
+
+    public readonly struct EnemyGaugeBrokenEvent
+    {
+        public readonly string EnemyId;
+
+        public EnemyGaugeBrokenEvent(string enemyId)
+        {
+            EnemyId = enemyId;
+        }
+    }
+
+    public readonly struct EnemyDownStartedEvent
+    {
+        public readonly string EnemyId;
+        public readonly float Duration;
+
+        public EnemyDownStartedEvent(string enemyId, float duration)
+        {
+            EnemyId = enemyId;
+            Duration = duration;
+        }
+    }
+
+    public readonly struct StageTiltStartedEvent
+    {
+        public readonly Vector3 TiltDirection;
+
+        public StageTiltStartedEvent(Vector3 tiltDirection)
+        {
+            TiltDirection = tiltDirection;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Events/GameEvents.cs.meta
+++ b/Assets/Scripts/Core/Events/GameEvents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99abf0beee144864abb803610b941b65

--- a/Assets/Scripts/UseCase/Enemy/EnemyActionUseCase.cs
+++ b/Assets/Scripts/UseCase/Enemy/EnemyActionUseCase.cs
@@ -54,8 +54,8 @@ namespace CreatorKousien.UseCase
         public void Execute(EnemyActionCommand command)
         {
             // 敵チーム全体の「合計3手」のプランを作成
-            List<ActionRuntimeData> teamPlan = PlanTeamActions();
-
+            List<ActionRuntimeData> teamPlan = PlanTeamActions(command.RollEnemyActTimes);
+            
             // コマンドの報告書に結果を書き込む
             command.OnPlanGenerated?.Invoke(teamPlan);
 
@@ -66,7 +66,7 @@ namespace CreatorKousien.UseCase
         /// 存在している全敵の中からステップごとに1体を指名し、チーム全体で3手のプランを作る
         /// </summary>
         /// <returns></returns>
-        private List<ActionRuntimeData> PlanTeamActions()
+        private List<ActionRuntimeData> PlanTeamActions(int rollEnemyActTimes)
         {
             var plan = new List<ActionRuntimeData>();
             var aliveEnemyIds = _enemySystem.GetAllAliveEnemyIds();
@@ -82,7 +82,7 @@ namespace CreatorKousien.UseCase
             }
 
             // チーム全体で3手分をループ
-            for (int step = 0; step < 3; step++)
+            for (int step = 0; step < rollEnemyActTimes; step++)
             {
                 // このステップで行動するエネミーを1体「ランダム」で指名する
                 int actingEnemyId = aliveEnemyIds[Random.Range(0, aliveEnemyIds.Count)];


### PR DESCRIPTION
## 概要
新アーキテクチャへの移行に向けた基盤構築と、完了済みタスクの整理を行いました。

## 変更内容
- Assets/_Project フォルダ構造（Runtime, Editor, Tests, Art）の作成 (#180)
- asmdef (Game.Runtime, Game.Editor, Game.Tests) の配置 (#180)
- コア契約（IEntity, IRuntimeData, ISystem）の定義 (#181)
- 既存の EventBus と GameEvents を Assets/_Project 配下に移動・整理 (#182)

## 影響範囲
- 既存の CreatorKousien.Core.Events を参照していたコードは修正が必要ですが、現在は Assets/_Project 配下への移行を優先しています。
