### PR TITLE
fix: アタッチメントの回転すり抜けるバグ修正

### DIFF
--- a/Assets/Prefab/Attachment/PFB_BulldozerBlade.prefab
+++ b/Assets/Prefab/Attachment/PFB_BulldozerBlade.prefab
@@ -345,6 +345,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4575287076364240601}
+  - component: {fileID: 8520920590429229808}
+  - component: {fileID: 2866212151138946041}
   m_Layer: 3
   m_Name: PFB_BulldozerBlade
   m_TagString: Untagged
@@ -372,6 +374,46 @@ Transform:
   - {fileID: 1621952861886609168}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &8520920590429229808
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6032332870982919000}
+  serializedVersion: 5
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &2866212151138946041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6032332870982919000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 28820b0626918bb48b0c1c3e1bd592e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Player.PhysicalAttachment
+  _spinSpeed: 360
 --- !u!1 &7161116677577071548
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/Player/PFB_Player.prefab
+++ b/Assets/Prefab/Player/PFB_Player.prefab
@@ -1053,8 +1053,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4777c775788bdc4080aa254a47bb13b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Player.PlayerAttachmentController
-  _attachmentPrefab: {fileID: 6032332870982919000, guid: 2ed8d690fdd51de4c9df47a2053aaf7d, type: 3}
-  _attachmentMountPoint: {fileID: 1983259960502521287}
+  _attachmentPrefab: {fileID: 2866212151138946041, guid: 2ed8d690fdd51de4c9df47a2053aaf7d, type: 3}
+  _attachmentSocket: {fileID: 1983259960502521287}
 --- !u!114 &5232212859440975684
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1084,7 +1084,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1983259960502521287}
   m_Layer: 0
-  m_Name: MousePoint
+  m_Name: AttachmentSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1099,7 +1099,7 @@ Transform:
   m_GameObject: {fileID: 5870560623095878439}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: -0.289, z: 0.487}
+  m_LocalPosition: {x: 0, y: -0.352, z: 0.487}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/Gameplay/Player/Attachment/PhysicalAttachment.cs
+++ b/Assets/Scripts/Gameplay/Player/Attachment/PhysicalAttachment.cs
@@ -1,0 +1,87 @@
+// ------------------------------------------------------------
+// File		: PhysicalAttachment.cs
+// Summary	: プレイヤーのソケットに追従しながら物理的に回転するアタッチメント
+//
+// Author	: [浅野 勇生]
+// Created	: 2026-05-18
+//
+// Notes	:
+// - ソケット追従によるすり抜け防止対策版
+// ------------------------------------------------------------
+using UnityEngine;
+
+namespace Game.Gameplay.Player
+{
+    /// <summary>
+    /// 物理演算に則ってソケットへ追従・回転するアタッチメントクラス
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody))]
+    public class PhysicalAttachment : MonoBehaviour
+    {
+        // 変数宣言
+        // ------------------------------------------------------------
+        private Rigidbody _rigidbody;           ///< 自身のリジットボディ
+        private Transform _targetSocket;        ///< 追従対象のソケット（Transform）
+
+        private Rigidbody _playerRigidbody;     ///< プレイヤー本体のリジットボディ
+        private Vector3 _localSocketPosition;   ///< ソケットのローカル位置
+        private Quaternion _localSocketRotation; ///< ソケットのローカル回転
+
+
+        // 関数処理
+        // ------------------------------------------------------------
+
+        /// <summary>
+        /// 初期化処理
+        /// </summary>
+        private void Awake()
+        {
+            _rigidbody = GetComponent<Rigidbody>();
+
+            // 物理設定を強制（設定漏れ防止）
+            _rigidbody.isKinematic = true;
+            _rigidbody.interpolation = RigidbodyInterpolation.Interpolate;
+            _rigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+        }
+
+
+        /// <summary>
+        /// 初期化処理 - 追従対象のソケットを設定
+        /// </summary>
+        /// <param name="targetSocket">追従対象のソケット</param>
+        public void Initialize(Transform targetSocket)
+        {
+            _targetSocket = targetSocket;
+
+            if (_targetSocket != null)
+            {
+                // ソケットの親オブジェクトからRigidbodyを取得
+                _playerRigidbody = _targetSocket.GetComponentInParent<Rigidbody>();
+
+                // プレイヤーからみたソケットの相対的な位置・回転を保存
+                _localSocketPosition = _targetSocket.localPosition;
+                _localSocketRotation = _targetSocket.localRotation;
+            }
+        }
+
+
+        /// <summary>
+        /// 物理演算の更新処理
+        /// </summary>
+        private void FixedUpdate()
+        {
+            if (_targetSocket == null || _playerRigidbody == null)
+            {
+                return;
+            }
+
+            // 1. 位置の計算
+            Vector3 calculatedTargetPos = _playerRigidbody.position + (_playerRigidbody.rotation * _localSocketPosition);
+            _rigidbody.MovePosition(calculatedTargetPos);
+
+            // 2. 回転の計算
+            Quaternion calculatedTargetRot = _playerRigidbody.rotation * _localSocketRotation;
+            _rigidbody.MoveRotation(calculatedTargetRot);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Player/Attachment/PhysicalAttachment.cs.meta
+++ b/Assets/Scripts/Gameplay/Player/Attachment/PhysicalAttachment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 28820b0626918bb48b0c1c3e1bd592e1

--- a/Assets/Scripts/Gameplay/Player/Attachment/PlayerAttachmentController.cs
+++ b/Assets/Scripts/Gameplay/Player/Attachment/PlayerAttachmentController.cs
@@ -21,12 +21,12 @@ namespace Game.Gameplay.Player
         // ------------------------------------------------------------
         [Header("アタッチメント設定")]
         [Tooltip("装備するアタッチメントのプレハブ")]
-        [SerializeField] private GameObject _attachmentPrefab;
+        [SerializeField] private PhysicalAttachment _attachmentPrefab;
 
         [Tooltip("アタッチメントの装着ポイント")]
-        [SerializeField] private Transform _attachmentMountPoint;
+        [SerializeField] private Transform _attachmentSocket;
 
-        private GameObject _currentAttachment;  ///< 現在装備しているアタッチメント
+        private PhysicalAttachment _currentAttachment;  ///< 現在装備しているアタッチメント
 
 
 
@@ -38,28 +38,43 @@ namespace Game.Gameplay.Player
         private void Start()
         {
             // 初期化処理
-            EquipAttachment(_attachmentPrefab);
+            SpawnAttachment();
         }
 
+
+
         /// <summary>
-        /// 指定されたアタッチメントを生成して装備する関数
+        /// アタッチメントを生成してセットアップする
         /// </summary>
-        /// <param name="prefab">生成するプレハブ</param>
-        public void EquipAttachment(GameObject prefab)
+        public void SpawnAttachment()
         {
-            if (prefab == null || _attachmentMountPoint == null)
+            if (_attachmentPrefab == null || _attachmentSocket == null)
             {
+                Debug.LogWarning("[PlayerAttachmentController] PrefabまたはSocketが設定されていません！");
                 return;
             }
 
-            // 既存のものがあれば破棄
+            // 1. Prefabを生成する（この時点ではプレイヤーの子にはせず、独立したオブジェクトとして生成）
+            _currentAttachment = Instantiate(_attachmentPrefab, _attachmentSocket.position, _attachmentSocket.rotation);
+
+            // 2. 生成したアタッチメントに、追従先となるソケット（目印）を教える
+            _currentAttachment.Initialize(_attachmentSocket);
+
+            Debug.Log("[PlayerAttachmentController] アタッチメントの生成と紐付けが完了しました。");
+        }
+
+
+
+
+        /// <summary>
+        /// プレイヤーが破棄されるとき、独立しているアタッチメントも一緒に破棄する
+        /// </summary>
+        private void OnDestroy()
+        {
             if (_currentAttachment != null)
             {
-                Destroy(_currentAttachment);
+                Destroy(_currentAttachment.gameObject);
             }
-
-            // アタッチメントを作成し、マウントポイントの子オブジェクト
-            _currentAttachment = Instantiate(prefab, _attachmentMountPoint.position, _attachmentMountPoint.rotation, _attachmentMountPoint);
         }
     }
 }


### PR DESCRIPTION
## 概要
*何のために何をしたか、簡潔に記述してください。*

## 変更内容
- アタッチメントの回転すり抜けバグを修正しました
- アタッチメントをプレイヤーの子オブジェクトから外して、あとはなんかいい感じに計算しました

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [x] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #254 

## その他 (懸念点・共有事項)
*特になければ削除してください。*
