### PR TITLE
fix: Playerの高さを参照して圧縮解放を行うように変更

### DIFF
--- a/Assets/Scripts/Gameplay/Collectibles/Entities/CompressCollectable.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Entities/CompressCollectable.cs
@@ -18,6 +18,7 @@ public class CompressCollectable : MonoBehaviour
 
     // 解放時の生成個数
     public int amount = 10;
+    public float expandHeight;
 
     public void OnStart()
     {// これうまくいってない
@@ -27,7 +28,7 @@ public class CompressCollectable : MonoBehaviour
     private void FixedUpdate()
     {
         // 位置から無理やり解放位置を指定
-        if(transform.position.y < 0.0f)
+        if(transform.position.y < expandHeight)
         {
             Expand();
         }

--- a/Assets/Scripts/Gameplay/Player/Collect/CollectableCompresser.cs
+++ b/Assets/Scripts/Gameplay/Player/Collect/CollectableCompresser.cs
@@ -65,6 +65,7 @@ public class CollectableCompresser : MonoBehaviour
             // 圧縮個数から解放時の個数を設定
             var comp = obj.GetComponent<CompressCollectable>();
             comp.amount = _compressAmount;
+            comp.expandHeight = gameObject.transform.position.y - 1.0f;
 
             // 圧縮対象のオブジェクトを削除と同時に種類を保存
             for (int i = 0; i < _compressAmount; ++i)
@@ -74,6 +75,7 @@ public class CollectableCompresser : MonoBehaviour
             }
 
             _nearbyCollectable.RemoveRange(0, _compressAmount);
+
         }
     }
 


### PR DESCRIPTION
## 概要
フィールド上で解放されるのを防ぐためPlayerの位置から解放位置を決定

## 変更内容
- Compresserのから解放位置を指定してフィールド上で拡散することを回避
- 

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [ x ] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ x ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [ x ] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [ x ] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ x ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ x ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ x ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #260 

## その他 (懸念点・共有事項)

