### PR TITLE
# 一回の攻撃で破壊/時間経過で大きく

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
+- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/Assets/Prefab/Collectible/PFB_SampleCrystal.prefab
+++ b/Assets/Prefab/Collectible/PFB_SampleCrystal.prefab
@@ -1,0 +1,1196 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1012019285842284965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6881782910394921228}
+  - component: {fileID: 6232481940070903390}
+  m_Layer: 0
+  m_Name: TargetGizmo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6881782910394921228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012019285842284965}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 3.71, z: -4.54}
+  m_LocalScale: {x: 1.1945, y: 1.3474, z: 1.1945}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 32793859887186653}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6232481940070903390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012019285842284965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 37d3ae54b5b577b4581f31b8f3ca38db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Collectibles.DrawVectorforGizmo
+  _origin: {fileID: 5929833088708329359}
+  _target: {fileID: 6881782910394921228}
+  _emissionAngle: 23.1
+--- !u!1 &2282477640888862281
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1158281452804460840}
+  m_Layer: 0
+  m_Name: Crystal1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1158281452804460840
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2282477640888862281}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0.28828177, w: 0.95754564}
+  m_LocalPosition: {x: 0.85045, y: -0.93644, z: 2.0149899}
+  m_LocalScale: {x: 0.5070342, y: 0.5070342, z: 0.5070342}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2213984359747119589}
+  m_Father: {fileID: 5858244252999994372}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -33.51}
+--- !u!1 &2636838753065319100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7264965889118763735}
+  - component: {fileID: 953626299295898064}
+  - component: {fileID: 7249460438148876765}
+  m_Layer: 0
+  m_Name: Crystal_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7264965889118763735
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2636838753065319100}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: -0.35355338, y: -0.35355338, z: 0}
+  m_LocalScale: {x: 1.4166667, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1132298246844422411}
+  m_Father: {fileID: 2213984359747119589}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &953626299295898064
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2636838753065319100}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7249460438148876765
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2636838753065319100}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &2865804566016663840
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1132298246844422411}
+  - component: {fileID: 1345649599173624570}
+  - component: {fileID: 8409017462439093896}
+  m_Layer: 0
+  m_Name: Crystal_3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1132298246844422411
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2865804566016663840}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7264965889118763735}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1345649599173624570
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2865804566016663840}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8409017462439093896
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2865804566016663840}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3426321653588685455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6239635505825225775}
+  - component: {fileID: 3894841261111064761}
+  - component: {fileID: 3091860942461456307}
+  m_Layer: 0
+  m_Name: Crystal_3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6239635505825225775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3426321653588685455}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 628362878710994507}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3894841261111064761
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3426321653588685455}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3091860942461456307
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3426321653588685455}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3550080456066088667
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8395013129469145799}
+  - component: {fileID: 8697333027581189477}
+  - component: {fileID: 2188041844680805617}
+  m_Layer: 0
+  m_Name: Crystal_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8395013129469145799
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3550080456066088667}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: -0.35355338, y: -0.35355338, z: 0}
+  m_LocalScale: {x: 1.4166667, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 117206202579138282}
+  m_Father: {fileID: 1302261096872280118}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8697333027581189477
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3550080456066088667}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2188041844680805617
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3550080456066088667}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3589349886498359717
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4441854280185567925}
+  m_Layer: 0
+  m_Name: Crystal2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4441854280185567925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3589349886498359717}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.1907052, w: 0.9816474}
+  m_LocalPosition: {x: -3.32955, y: -1.2964401, z: 1.9879904}
+  m_LocalScale: {x: 0.52511555, y: 0.52511555, z: 0.52511555}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 975911488660997794}
+  m_Father: {fileID: 5858244252999994372}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 21.988}
+--- !u!1 &3811291360358060276
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 628362878710994507}
+  - component: {fileID: 7495637921030801661}
+  - component: {fileID: 8406899423515795627}
+  m_Layer: 0
+  m_Name: Crystal_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &628362878710994507
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3811291360358060276}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: -0.35355338, y: -0.35355338, z: 0}
+  m_LocalScale: {x: 1.4166667, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6239635505825225775}
+  m_Father: {fileID: 975911488660997794}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7495637921030801661
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3811291360358060276}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8406899423515795627
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3811291360358060276}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4301146049621042606
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2651561382517236546}
+  m_Layer: 0
+  m_Name: pivot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2651561382517236546
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4301146049621042606}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.56285, z: 0}
+  m_LocalScale: {x: 1.1945, y: 1.3474, z: 1.1945}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5858244252999994372}
+  m_Father: {fileID: 32793859887186653}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4969973644305817149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 32793859887186653}
+  - component: {fileID: 161420641022990971}
+  - component: {fileID: 2002147344956736233}
+  - component: {fileID: 7867337310766874309}
+  - component: {fileID: 4253139232898160154}
+  m_Layer: 0
+  m_Name: PFB_SampleCrystal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &32793859887186653
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4969973644305817149}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.15, y: 1.19, z: 11.52}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2651561382517236546}
+  - {fileID: 6881782910394921228}
+  - {fileID: 5929833088708329359}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &161420641022990971
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4969973644305817149}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 5.42, y: 3.5, z: 4.3}
+  m_Center: {x: 0, y: 0, z: -1}
+--- !u!114 &2002147344956736233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4969973644305817149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af9264d7e43a6844f8cfe0b8bb5776bf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Collectibles.CrystalShardEmitter
+  _pool: {fileID: 0}
+  _registry: {fileID: 0}
+  _shardData: []
+  _canBeCollectedByPlayer: 1
+  _amountMode: 0
+  _fixedShardCount: 3
+  _crystalSize: 1
+  _smallCount:
+    Min: 1
+    Max: 3
+  _mediumCount:
+    Min: 3
+    Max: 6
+  _largeCount:
+    Min: 6
+    Max: 10
+  _emitOrigin: {fileID: 5929833088708329359}
+  _spawnRadius: 5
+  _minLaunchSpeed: 4
+  _maxLaunchSpeed: 5
+  _upwardBias: 0.75
+  _randomSpread: 0.45
+  _minAngularSpeed: 2
+  _maxAngularSpeed: 8
+--- !u!114 &7867337310766874309
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4969973644305817149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ee757739a93e5a43956ed8bb9154481, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Collectibles.CrystalInteractable
+  _emitter: {fileID: 2002147344956736233}
+  _hitOrigin: {fileID: 6881782910394921228}
+  _interactionPower: 1
+  _interactCooldown: 0.35
+--- !u!114 &4253139232898160154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4969973644305817149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5925402ccb8f39b448c17c08ed47454e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Data.Collectibles.CrystalOneBreakforScale
+  _gizmo: {fileID: 6232481940070903390}
+  _mainCrystal: {fileID: 2651561382517236546}
+  _shardEmitter: {fileID: 2002147344956736233}
+  _shard:
+  - Data: {fileID: 11400000, guid: 94e9ae19b8865d2489f8111fcf489a3e, type: 2}
+    Weight: 0.8
+  - Data: {fileID: 11400000, guid: c98775c619051ab4bb85497465249d77, type: 2}
+    Weight: 0.2
+  _min: 5
+  _max: 10
+  _crystalInitScale: 1.5
+  CrystalMaxScale: {x: 1, y: 1, z: 1}
+  EmissionPower: 10
+  MaxScaleCount: 10
+  _currentScaleCount: 0
+--- !u!1 &5254429854638811847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2213984359747119589}
+  - component: {fileID: 1686570519516828874}
+  - component: {fileID: 8295698889712845296}
+  m_Layer: 0
+  m_Name: Crystal_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2213984359747119589
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5254429854638811847}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: 0.71437, y: 2.18944, z: 1.5}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7264965889118763735}
+  m_Father: {fileID: 1158281452804460840}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
+--- !u!33 &1686570519516828874
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5254429854638811847}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8295698889712845296
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5254429854638811847}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &6662701950395505109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 975911488660997794}
+  - component: {fileID: 7215827985899341554}
+  - component: {fileID: 2816811762888157321}
+  m_Layer: 0
+  m_Name: Crystal_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &975911488660997794
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6662701950395505109}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: 0.71437, y: 2.18944, z: 1.5}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 628362878710994507}
+  m_Father: {fileID: 4441854280185567925}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
+--- !u!33 &7215827985899341554
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6662701950395505109}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2816811762888157321
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6662701950395505109}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &6879202313935624603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5858244252999994372}
+  m_Layer: 0
+  m_Name: Mesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5858244252999994372
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6879202313935624603}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.86, y: 2.96, z: -2.55}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3899632748681385081}
+  - {fileID: 1158281452804460840}
+  - {fileID: 4441854280185567925}
+  m_Father: {fileID: 2651561382517236546}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7276928140766766810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1302261096872280118}
+  - component: {fileID: 6998641905846306291}
+  - component: {fileID: 2470709150617304878}
+  m_Layer: 0
+  m_Name: Crystal_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1302261096872280118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7276928140766766810}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: 0.71437, y: 2.18944, z: 1.5}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8395013129469145799}
+  m_Father: {fileID: 3899632748681385081}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
+--- !u!33 &6998641905846306291
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7276928140766766810}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2470709150617304878
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7276928140766766810}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7539939272618082901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 117206202579138282}
+  - component: {fileID: 7464513298248144966}
+  - component: {fileID: 5283615695750055773}
+  m_Layer: 0
+  m_Name: Crystal_3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &117206202579138282
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7539939272618082901}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8395013129469145799}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7464513298248144966
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7539939272618082901}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5283615695750055773
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7539939272618082901}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: bc61b87e16fb73d47b145c2ef05366fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8840476857808064850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3899632748681385081}
+  m_Layer: 0
+  m_Name: Crystal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3899632748681385081
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8840476857808064850}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.28661, y: -0.22643995, z: 1.7529898}
+  m_LocalScale: {x: 0.6818, y: 0.6818, z: 0.6818}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1302261096872280118}
+  m_Father: {fileID: 5858244252999994372}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9018726371267511393
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5929833088708329359}
+  m_Layer: 0
+  m_Name: origin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5929833088708329359
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9018726371267511393}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.8489997, z: -2.4060001}
+  m_LocalScale: {x: 1.1945, y: 1.3474, z: 1.1945}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 32793859887186653}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefab/Collectible/PFB_SampleCrystal.prefab.meta
+++ b/Assets/Prefab/Collectible/PFB_SampleCrystal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 93df8fe678bc72b40b8682e2a919bb92
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Collectibles/Management/CrystalOneBreakforScale.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/CrystalOneBreakforScale.cs
@@ -1,0 +1,87 @@
+using UnityEngine;
+using Game.Data.Collectibles;
+using System;
+using TMPro;
+using Game.Gameplay.Collectibles;
+
+namespace Game.Data.Collectibles
+{
+    public class CrystalOneBreakforScale : MonoBehaviour
+    {
+        // サイズによる欠片生成量
+        [Serializable]
+        public struct CollectiblesCount
+        {
+            [Min(1)] public int _min;
+            [Min(1)] public int _max;
+        }
+
+        [SerializeField] private DrawVectorforGizmo _gizmo;
+        [SerializeField] private Transform _mainCrystal;
+        [SerializeField] private CrystalShardEmitter _shardEmitter;
+
+        [SerializeField] public CrystalShardEmitter.WeightedShardData[] _shard;
+
+        //--- サイズによる欠片生成量の上下限
+        [SerializeField, Min(1)] public int _min = 1;
+        [SerializeField, Min(5)] public int _max = 1;
+
+        // 初期サイズ倍率
+        [SerializeField] private float _crystalInitScale = 1.5F;
+
+        // サイズ上限 この上限を基準に欠片の生成量が決まる
+        [SerializeField] public Vector3 CrystalMaxScale = new Vector3(1.5f,1.5f,1.5f);
+
+        // 射出力の倍率
+        [SerializeField] private float EmissionPower = 1.0F;
+
+        // 最大になるまでの秒数(float)
+        [SerializeField] public float MaxScaleCount = 10.0F;
+
+        [SerializeField]private float _currentScaleCount;
+
+        private Vector3 _emitVector;
+
+        // Start is called once before the first execution of Update after the MonoBehaviour is created
+        void Start()
+        {
+            gameObject.transform.localScale = CrystalMaxScale * _crystalInitScale;
+            _currentScaleCount = _crystalInitScale;
+            if(_gizmo != null)
+            {
+                _emitVector = (_gizmo._origin.transform.position - _gizmo._target.transform.position).normalized;
+            }
+        }
+    
+        // Update is called once per frame
+        void FixedUpdate()
+        {
+            // 最大時間を超過している場合秒数を更新しない
+            if(_currentScaleCount >= MaxScaleCount)
+            {
+                _currentScaleCount = MaxScaleCount;
+            }
+            // そうでない場合更新
+            else
+            {
+                _currentScaleCount += Time.deltaTime;
+            }
+
+            // サイズに最大から現在の経過時間でサイズを更新
+            gameObject.transform.localScale = CrystalMaxScale * (_currentScaleCount / MaxScaleCount);
+        }
+
+        [ContextMenu("DEBUG: Emit Shards")]
+        public void Emits()
+        {
+            if(_shardEmitter != null)
+            {
+                int max = UnityEngine.Random.Range(_min, _max);
+                for(int i = 0; i < max;i++)
+                _shardEmitter.Emitter(_emitVector,_gizmo._emissionAngle,EmissionPower,_shard);
+            }
+            _currentScaleCount = 0.00001f;
+        }
+    }
+
+}

--- a/Assets/Scripts/Gameplay/Collectibles/Management/CrystalOneBreakforScale.cs.meta
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/CrystalOneBreakforScale.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5925402ccb8f39b448c17c08ed47454e

--- a/Assets/Scripts/Gameplay/Collectibles/Management/CrystalShardEmitter.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/CrystalShardEmitter.cs
@@ -55,6 +55,23 @@ namespace Game.Gameplay.Collectibles
         }
 
         /// <summary>
+        /// 生成候補となる欠片データと抽選重みを保持します。
+        /// </summary>
+        [Serializable]
+        public struct WeightedShardData
+        {
+            /// <summary>
+            /// 生成対象の欠片データです。
+            /// </summary>
+            public CollectibleData Data;
+
+            /// <summary>
+            /// 欠片データの抽選重みです。
+            /// </summary>
+            [Min(0f)] public float Weight;
+        }
+
+        /// <summary>
         /// 欠片発生数の最小値と最大値を保持する設定。
         /// </summary>
         [Serializable]
@@ -144,7 +161,7 @@ namespace Game.Gameplay.Collectibles
         /// <summary>
         /// 発生位置を基準点からどれくらいランダムに散らすか。
         /// </summary>
-        [SerializeField, Min(0f)] private float _spawnRadius = 0.25f;
+        [SerializeField, Min(0f)] private float _spawnRadius = 1.0f;
 
         /// <summary>
         /// 欠片に与える初速の最小値。
@@ -194,6 +211,18 @@ namespace Game.Gameplay.Collectibles
         }
 
         /// <summary>
+        /// 指定方向と重み付き欠片テーブルから欠片を 1 つ生成します。
+        /// </summary>
+        /// <param name="direction">欠片の基準移動方向です。</param>
+        /// <param name="randomRange">基準方向へ加えるランダム方向の強さです。</param>
+        /// <param name="movementAmount">欠片へ与える移動量です。</param>
+        /// <param name="shardTable">重み付き欠片データの配列です。</param>
+        public void Emitter(Vector3 direction, float randomRange, float movementAmount, WeightedShardData[] shardTable)
+        {
+            EmitOne(GetBasePosition(transform.position), direction, randomRange, movementAmount, shardTable);
+        }
+
+        /// <summary>
         /// プレイヤーの攻撃判定、またはヒット検知側から呼ぶ欠片発生 API。
         /// </summary>
         /// <param name="hitPoint">クリスタルが殴られたワールド座標。</param>
@@ -216,6 +245,19 @@ namespace Game.Gameplay.Collectibles
         }
 
         /// <summary>
+        /// 指定位置と重み付き欠片テーブルから欠片を 1 つ生成します。
+        /// </summary>
+        /// <param name="hitPoint">欠片の発生位置です。</param>
+        /// <param name="direction">欠片の基準移動方向です。</param>
+        /// <param name="randomRange">基準方向へ加えるランダム方向の強さです。</param>
+        /// <param name="movementAmount">欠片へ与える移動量です。</param>
+        /// <param name="shardTable">重み付き欠片データの配列です。</param>
+        public void EmitFromHit(Vector3 hitPoint, Vector3 direction, float randomRange, float movementAmount, WeightedShardData[] shardTable)
+        {
+            EmitOne(hitPoint, direction, randomRange, movementAmount, shardTable);
+        }
+
+        /// <summary>
         /// 欠片を 1 個だけ生成し、位置、見た目データ、初速、角速度、Registry 登録を行う。
         /// </summary>
         /// <param name="hitPoint">発生位置計算に使うヒット座標。</param>
@@ -230,6 +272,37 @@ namespace Game.Gameplay.Collectibles
             shard.transform.rotation = UnityEngine.Random.rotation;
             shard.Initialize(data, ReturnToPool, _canBeCollectedByPlayer);
             shard.SetInitialMotion(CreateVelocity(hitDirection, power), CreateAngularVelocity());
+
+            _registry.Register(shard);
+        }
+
+        /// <summary>
+        /// 重み付き欠片テーブルから抽選した欠片を 1 つ生成します。
+        /// </summary>
+        /// <param name="hitPoint">欠片の発生位置です。</param>
+        /// <param name="direction">欠片の基準移動方向です。</param>
+        /// <param name="randomRange">基準方向へ加えるランダム方向の強さです。</param>
+        /// <param name="movementAmount">欠片へ与える移動量です。</param>
+        /// <param name="shardTable">重み付き欠片データの配列です。</param>
+        private void EmitOne(Vector3 hitPoint, Vector3 direction, float randomRange, float movementAmount, WeightedShardData[] shardTable)
+        {
+            ResolveReferencesIfNeeded();
+
+            if (!CanUseSpawnApi())
+            {
+                return;
+            }
+
+            if (!TrySelectWeightedShardData(shardTable, out CollectibleData data))
+            {
+                return;
+            }
+
+            CollectibleObject shard = _pool.Get();
+            shard.transform.position = CreateSpawnPosition(hitPoint);
+            shard.transform.rotation = UnityEngine.Random.rotation;
+            shard.Initialize(data, ReturnToPool, _canBeCollectedByPlayer);
+            shard.SetInitialMotion(CreateWeightedVelocity(direction, randomRange, movementAmount), CreateAngularVelocity());
 
             _registry.Register(shard);
         }
@@ -309,6 +382,28 @@ namespace Game.Gameplay.Collectibles
         }
 
         /// <summary>
+        /// 重み付き生成 API 用の移動ベクトルを作成します。
+        /// </summary>
+        /// <param name="direction">欠片の基準移動方向です。</param>
+        /// <param name="randomRange">基準方向へ加えるランダム方向の強さです。</param>
+        /// <param name="movementAmount">欠片へ与える移動量です。</param>
+        /// <returns>SetInitialMotion に渡す移動ベクトルです。</returns>
+        private Vector3 CreateWeightedVelocity(Vector3 direction, float randomRange, float movementAmount)
+        {
+            Vector3 baseDirection = direction.sqrMagnitude > 0.0001f
+                ? direction.normalized
+                : transform.up;
+
+            Vector3 finalDirection = baseDirection + UnityEngine.Random.insideUnitSphere * Mathf.Max(0f, randomRange);
+            if (finalDirection.sqrMagnitude < 0.0001f)
+            {
+                finalDirection = Vector3.up;
+            }
+
+            return finalDirection.normalized * Mathf.Max(0f, movementAmount);
+        }
+
+        /// <summary>
         /// 欠片に与えるランダムな角速度を作る。
         /// </summary>
         /// <returns>SetInitialMotion に渡す角速度ベクトル。</returns>
@@ -338,6 +433,96 @@ namespace Game.Gameplay.Collectibles
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// 新しい生成 API で必要な参照が揃っているかを確認します。
+        /// </summary>
+        /// <returns>生成 API を利用できる場合は true を返します。</returns>
+        private bool CanUseSpawnApi()
+        {
+            if (_pool == null || _registry == null)
+            {
+                Debug.LogError("[CrystalShardEmitter] CollectiblePool or CollectibleRegistry is missing.", this);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 重み付き欠片テーブルから欠片データを抽選します。
+        /// </summary>
+        /// <param name="shardTable">重み付き欠片データの配列です。</param>
+        /// <param name="data">抽選結果の欠片データです。</param>
+        /// <returns>抽選に成功した場合は true を返します。</returns>
+        private bool TrySelectWeightedShardData(WeightedShardData[] shardTable, out CollectibleData data)
+        {
+            data = null;
+
+            if (shardTable == null || shardTable.Length == 0)
+            {
+                Debug.LogError("[CrystalShardEmitter] Weighted shard data is missing.", this);
+                return false;
+            }
+
+            float totalWeight = 0f;
+            int validCount = 0;
+            for (int i = 0; i < shardTable.Length; i++)
+            {
+                WeightedShardData candidate = shardTable[i];
+                if (candidate.Data == null || candidate.Weight <= 0f || float.IsNaN(candidate.Weight) || float.IsInfinity(candidate.Weight))
+                {
+                    continue;
+                }
+
+                totalWeight += candidate.Weight;
+                validCount++;
+            }
+
+            if (validCount == 0)
+            {
+                Debug.LogError("[CrystalShardEmitter] Weighted shard data is missing.", this);
+                return false;
+            }
+
+            if (totalWeight <= 0f || float.IsNaN(totalWeight) || float.IsInfinity(totalWeight))
+            {
+                Debug.LogError("[CrystalShardEmitter] Weighted shard weight is invalid.", this);
+                return false;
+            }
+
+            float randomWeight = UnityEngine.Random.value * totalWeight;
+            float cumulativeWeight = 0f;
+
+            for (int i = 0; i < shardTable.Length; i++)
+            {
+                WeightedShardData candidate = shardTable[i];
+                if (candidate.Data == null || candidate.Weight <= 0f || float.IsNaN(candidate.Weight) || float.IsInfinity(candidate.Weight))
+                {
+                    continue;
+                }
+
+                cumulativeWeight += candidate.Weight;
+                if (randomWeight <= cumulativeWeight)
+                {
+                    data = candidate.Data;
+                    return true;
+                }
+            }
+
+            for (int i = shardTable.Length - 1; i >= 0; i--)
+            {
+                WeightedShardData candidate = shardTable[i];
+                if (candidate.Data != null && candidate.Weight > 0f && !float.IsNaN(candidate.Weight) && !float.IsInfinity(candidate.Weight))
+                {
+                    data = candidate.Data;
+                    return true;
+                }
+            }
+
+            Debug.LogError("[CrystalShardEmitter] Weighted shard data is missing.", this);
+            return false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Gameplay/Collectibles/Management/DrawVectorforGizmo.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/DrawVectorforGizmo.cs
@@ -1,0 +1,140 @@
+// ================================================================================
+// File         : ShardEmissionVector.cs
+// Description  : Scene-editable origin, target, and angle for shard emission.
+// ================================================================================
+
+using UnityEngine;
+
+namespace Game.Gameplay.Collectibles
+{
+    /// <summary>
+    /// 欠片の射出元、射出先、射出角度を Scene 上で設定するコンポーネント。
+    /// 射出処理は持たず、CrystalShardEmitter へ方向情報を提供する。
+    /// </summary>
+    public sealed class DrawVectorforGizmo : MonoBehaviour
+    {
+        /// <summary>
+        /// 欠片を生成する位置。未設定の場合はこのコンポーネント自身の Transform を使う。
+        /// </summary>
+        [SerializeField] public Transform _origin;
+
+        /// <summary>
+        /// 欠片を飛ばす中心位置。Scene 上でこの Transform を移動すると射出方向が変わる。
+        /// </summary>
+        [SerializeField] public Transform _target;
+
+        /// <summary>
+        /// Target 方向から何度まで欠片を散らすか。
+        /// </summary>
+        [SerializeField, Range(0f, 89f)] public float _emissionAngle = 35.0f;
+
+        /// <summary>
+        /// 欠片を生成するワールド座標。
+        /// </summary>
+        public Vector3 OriginPosition => _origin != null ? _origin.position : transform.position;
+
+        /// <summary>
+        /// 射出範囲の中心となる正規化済み方向。
+        /// </summary>
+        public Vector3 Direction
+        {
+            get
+            {
+                if (_target == null)
+                {
+                    return Vector3.forward;
+                }
+
+                Vector3 direction = _target.position - OriginPosition;
+                return direction.sqrMagnitude > 0.01f ? direction.normalized : Vector3.forward;
+            }
+        }
+
+        /// <summary>
+        /// 欠片を散らす最大角度。
+        /// </summary>
+        public float EmissionAngle => Mathf.Clamp(_emissionAngle, 0f, 89f);
+
+        /// <summary>
+        /// 射出先が設定され、方向計算を行えるかを返す。
+        /// </summary>
+        public bool HasTarget => _target != null;
+
+        /// <summary>
+        /// Scene 上で射出元、中心方向、射出可能範囲を表示する。
+        /// オレンジ色の矢印が中心方向、水色の円錐が散らばる範囲を表す。
+        /// </summary>
+        private void OnDrawGizmosSelected()
+        {
+            if (_target == null)
+            {
+                return;
+            }
+
+            Vector3 origin = OriginPosition;
+            Vector3 targetOffset = _target.position - origin;
+            float length = targetOffset.magnitude;
+            if (length < 0.01f)
+            {
+                return;
+            }
+
+            Vector3 centerDirection = targetOffset.normalized;
+            float radius = Mathf.Tan(EmissionAngle * Mathf.Deg2Rad) * length;
+
+            Gizmos.color = new Color(0.1f, 0.8f, 1.0f, 0.9f);
+            Gizmos.DrawWireSphere(origin, 0.05f);
+
+            const int segmentCount = 16;
+            Vector3 perpendicular = GetPerpendicular(centerDirection);
+            Vector3 previousPoint = Vector3.zero;
+
+            for (int i = 0; i <= segmentCount; i++)
+            {
+                float rotation = 360f * i / segmentCount;
+                Vector3 radialDirection = Quaternion.AngleAxis(rotation, centerDirection) * perpendicular;
+                Vector3 point = origin + centerDirection * length + radialDirection * radius;
+
+                Gizmos.DrawLine(origin, point);
+
+                if (i > 0)
+                {
+                    Gizmos.DrawLine(previousPoint, point);
+                }
+
+                previousPoint = point;
+            }
+
+            DrawDirectionArrow(origin, centerDirection, length);
+        }
+
+        /// <summary>
+        /// Scene 上で欠片の中心方向を確認できる矢印 Gizmo を描画する。
+        /// </summary>
+        private static void DrawDirectionArrow(Vector3 origin, Vector3 direction, float length)
+        {
+            Vector3 tip = origin + direction * length;
+            float headLength = Mathf.Min(length * 0.25f, 0.5f);
+            Vector3 perpendicular = GetPerpendicular(direction);
+            Vector3 secondPerpendicular = Vector3.Cross(direction, perpendicular).normalized;
+
+            Gizmos.color = new Color(1.0f, 0.35f, 0.1f, 1.0f);
+            Gizmos.DrawLine(origin, tip);
+            Gizmos.DrawLine(tip, tip - direction * headLength + perpendicular * headLength * 0.5f);
+            Gizmos.DrawLine(tip, tip - direction * headLength - perpendicular * headLength * 0.5f);
+            Gizmos.DrawLine(tip, tip - direction * headLength + secondPerpendicular * headLength * 0.5f);
+            Gizmos.DrawLine(tip, tip - direction * headLength - secondPerpendicular * headLength * 0.5f);
+        }
+
+        /// <summary>
+        /// 指定方向と直交するベクトルを作る。
+        /// </summary>
+        private static Vector3 GetPerpendicular(Vector3 direction)
+        {
+            Vector3 axis = Mathf.Abs(Vector3.Dot(direction, Vector3.up)) < 0.99f
+                ? Vector3.up
+                : Vector3.right;
+            return Vector3.Cross(direction, axis).normalized;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Collectibles/Management/DrawVectorforGizmo.cs.meta
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/DrawVectorforGizmo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 37d3ae54b5b577b4581f31b8f3ca38db


### PR DESCRIPTION
## 概要
*時間経過で段々大きくなりその分生成される欠片の数も増えるようになっているはずです。*
*また、一回の攻撃で破壊され、処理的にはめっっっちゃ小さくなっています。*

## 変更内容
- CrystalShardEmitterに今回必要になった関数を追加。追加に伴うエラーはでないです。
- CrystalOneBreakforScale/DrawVectorforGizmoをそれぞれ追加
- CrtstalOneBreackの方では一撃破壊を行える関数を用意(Emits)し、ShardEmitterから欠片を生成しますが、欠片を選ぶのはOneBreakの方になり、ShardEmitterの方で欠片を設定しても反映はされません。代わりに、重みを追加しレア度による出やすさを数値で変更できるようにOneBreakの方で変更をかけました。
- DrawVectorの方ではgizmo表示で視覚的にわかりやすいのと、その情報をOneBreakに渡す用に作成

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [ ] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [ ] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [ ] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #296 

