### PR TITLE
[#361] 暗い森向けの局所フォグ表現を追加する

### DIFF
--- a/Assets/Materials/Field/M_Fog.mat
+++ b/Assets/Materials/Field/M_Fog.mat
@@ -1,0 +1,156 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: M_Fog
+  m_Shader: {fileID: 4800000, guid: e60948de9ba6b404295a6b47e7b45b67, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NoiseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _Alpha: 0.58
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DepthFadeDistance: 6
+    - _Dissolve: 0.38
+    - _DissolveSoftness: 0.38
+    - _DepthFadeStrength: 1
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _BreathStrength: 0.18
+    - _EdgeFade: 0.72
+    - _EdgeNoiseStrength: 0.55
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _NoiseScale: 0.35
+    - _NoiseStrength: 0.82
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _Puffiness: 0.86
+    - _Turbulence: 0.72
+    - _WarpStrength: 1.25
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 1
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 0
+    m_Colors:
+    - _BaseColor: {r: 0.045, g: 0.065, b: 0.06, a: 0.62}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _NoiseSpeed: {r: 0.32, g: 0.11, b: 0, a: 0}
+    - _WindDirection: {r: 0.85, g: 0.35, b: 0, a: 0}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &4159562191888135104
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Editor::UnityEditor.Rendering.Universal.AssetVersion
+  version: 10

--- a/Assets/Materials/Field/M_Fog.mat.meta
+++ b/Assets/Materials/Field/M_Fog.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 006941a41ac82714cb5f75a5fa98ee29
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Field/SH_Fog.shader
+++ b/Assets/Materials/Field/SH_Fog.shader
@@ -1,0 +1,213 @@
+Shader "Custom/SH_Fog"
+{
+    Properties
+    {
+        [MainColor] _BaseColor("Base Color", Color) = (0.045, 0.065, 0.06, 0.62)
+        [MainTexture] _BaseMap("Base Map", 2D) = "white" {}
+        _Alpha("Alpha", Range(0, 1)) = 0.58
+        _NoiseStrength("Noise Strength", Range(0, 1)) = 0.82
+        _NoiseScale("Noise Scale", Float) = 0.35
+        _NoiseSpeed("Noise Speed", Vector) = (0.32, 0.11, 0, 0)
+        _WindDirection("Wind Direction", Vector) = (0.85, 0.35, 0, 0)
+        _WarpStrength("Warp Strength", Range(0, 2)) = 1.25
+        _Turbulence("Turbulence", Range(0, 1)) = 0.72
+        _Puffiness("Puffiness", Range(0, 1)) = 0.86
+        _BreathStrength("Breath Strength", Range(0, 0.4)) = 0.18
+        _DepthFadeStrength("Depth Fade Strength", Range(0, 1)) = 1
+        _DepthFadeDistance("Depth Fade Distance", Float) = 6
+        _EdgeFade("Edge Fade", Range(0.001, 0.95)) = 0.72
+        _EdgeNoiseStrength("Edge Noise Strength", Range(0, 0.9)) = 0.55
+        _Dissolve("Dissolve", Range(0, 1)) = 0.38
+        _DissolveSoftness("Dissolve Softness", Range(0.01, 0.7)) = 0.38
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Transparent"
+            "Queue" = "Transparent"
+            "RenderPipeline" = "UniversalPipeline"
+            "IgnoreProjector" = "True"
+        }
+
+        Pass
+        {
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite Off
+            Cull Off
+
+            HLSLPROGRAM
+
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionHCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 positionWS : TEXCOORD1;
+                float4 screenPosition : TEXCOORD2;
+            };
+
+            TEXTURE2D(_BaseMap);
+            SAMPLER(sampler_BaseMap);
+
+            CBUFFER_START(UnityPerMaterial)
+                half4 _BaseColor;
+                float4 _BaseMap_ST;
+                half _Alpha;
+                half _NoiseStrength;
+                float _NoiseScale;
+                float2 _NoiseSpeed;
+                float2 _WindDirection;
+                half _WarpStrength;
+                half _Turbulence;
+                half _Puffiness;
+                half _BreathStrength;
+                half _DepthFadeStrength;
+                float _DepthFadeDistance;
+                float _EdgeFade;
+                half _EdgeNoiseStrength;
+                half _Dissolve;
+                half _DissolveSoftness;
+            CBUFFER_END
+
+            Varyings vert(Attributes IN)
+            {
+                Varyings OUT;
+                OUT.positionWS = TransformObjectToWorld(IN.positionOS.xyz);
+                OUT.positionHCS = TransformWorldToHClip(OUT.positionWS);
+                OUT.uv = TRANSFORM_TEX(IN.uv, _BaseMap);
+                OUT.screenPosition = ComputeScreenPos(OUT.positionHCS);
+                return OUT;
+            }
+
+            /// <summary>
+            /// テクスチャ未設定でも霧が白い板にならないよう、手続き型ノイズを生成する。
+            /// </summary>
+            float Hash21(float2 value)
+            {
+                value = frac(value * float2(123.34, 345.45));
+                value += dot(value, value + 34.345);
+                return frac(value.x * value.y);
+            }
+
+            /// <summary>
+            /// なめらかな値ノイズを返す。
+            /// </summary>
+            float ValueNoise(float2 value)
+            {
+                float2 cell = floor(value);
+                float2 local = frac(value);
+                float2 curve = local * local * (3.0 - 2.0 * local);
+
+                float bottomLeft = Hash21(cell);
+                float bottomRight = Hash21(cell + float2(1.0, 0.0));
+                float topLeft = Hash21(cell + float2(0.0, 1.0));
+                float topRight = Hash21(cell + float2(1.0, 1.0));
+
+                float bottom = lerp(bottomLeft, bottomRight, curve.x);
+                float top = lerp(topLeft, topRight, curve.x);
+                return lerp(bottom, top, curve.y);
+            }
+
+            /// <summary>
+            /// 複数スケールのノイズを重ね、自然な霧の塊を作る。
+            /// </summary>
+            float FractionalBrownianMotion(float2 value)
+            {
+                float sum = 0.0;
+                float amplitude = 0.5;
+
+                [unroll]
+                for (int index = 0; index < 4; index++)
+                {
+                    sum += ValueNoise(value) * amplitude;
+                    value = value * 2.03 + float2(19.19, 7.31);
+                    amplitude *= 0.52;
+                }
+
+                return saturate(sum);
+            }
+
+            /// <summary>
+            /// ノイズ座標をゆっくり歪ませ、直線的に流れるだけの動きを避ける。
+            /// </summary>
+            float2 CalculateFlowUv(float2 worldUv, float time)
+            {
+                float2 wind = normalize(_WindDirection + 0.0001);
+                float2 crossWind = float2(-wind.y, wind.x);
+                float2 mainDrift = wind * time * _NoiseSpeed.x;
+                float2 crossDrift = crossWind * sin(time * 0.47) * _NoiseSpeed.y;
+
+                float warpA = FractionalBrownianMotion(worldUv * 0.7 + mainDrift * 0.9 + time * 0.09);
+                float warpB = FractionalBrownianMotion(worldUv * 0.7 - crossDrift * 1.1 - time * 0.07);
+                float2 warp = (float2(warpA, warpB) - 0.5) * _WarpStrength;
+
+                return worldUv + mainDrift + crossDrift + warp;
+            }
+
+            /// <summary>
+            /// 地形との交差部分を柔らかくして、板ポリ感を抑える。
+            /// </summary>
+            half CalculateDepthFade(float4 screenPosition, float3 positionWS)
+            {
+                float2 screenUv = screenPosition.xy / screenPosition.w;
+                float sceneRawDepth = SampleSceneDepth(screenUv);
+                float sceneEyeDepth = LinearEyeDepth(sceneRawDepth, _ZBufferParams);
+                float surfaceEyeDepth = -TransformWorldToView(positionWS).z;
+                half depthFade = saturate((sceneEyeDepth - surfaceEyeDepth) / max(_DepthFadeDistance, 0.001));
+                return lerp(1.0, depthFade, _DepthFadeStrength);
+            }
+
+            /// <summary>
+            /// メッシュ外周の直線的な境界を薄くして、霧の切れ目を隠す。
+            /// </summary>
+            half CalculateEdgeFade(float2 uv, half edgeNoise)
+            {
+                float2 edgeDistance = min(uv, 1.0 - uv);
+                float noisyEdge = min(edgeDistance.x, edgeDistance.y);
+                noisyEdge += (edgeNoise - 0.5) * _EdgeNoiseStrength;
+                return smoothstep(0.0, _EdgeFade, noisyEdge);
+            }
+
+            half4 frag(Varyings IN) : SV_Target
+            {
+                float2 worldUv = IN.positionWS.xz * max(_NoiseScale, 0.001);
+                float time = _Time.y;
+                float2 flowUv = CalculateFlowUv(worldUv, time);
+                float2 detailUv = CalculateFlowUv(worldUv * 2.4 + 17.0, time * 0.73);
+                float2 edgeUv = IN.uv * 2.6 + CalculateFlowUv(worldUv * 0.55 + 5.0, time * 0.38);
+
+                float slowNoise = FractionalBrownianMotion(flowUv);
+                float detailNoise = FractionalBrownianMotion(detailUv);
+                float edgeNoise = FractionalBrownianMotion(edgeUv);
+                float turbulentNoise = FractionalBrownianMotion(flowUv * 5.0 + float2(time * -0.28, time * 0.41));
+
+                half baseAlpha = SAMPLE_TEXTURE2D(_BaseMap, sampler_BaseMap, IN.uv).a;
+                half noise = saturate(slowNoise * 0.68 + detailNoise * 0.22 + turbulentNoise * _Turbulence * 0.18);
+                half puffMask = lerp(noise, smoothstep(_Dissolve, saturate(_Dissolve + _DissolveSoftness), noise), _Puffiness);
+                half breathNoise = FractionalBrownianMotion(worldUv * 1.15 + time * 0.24);
+                half breath = 1.0 + (breathNoise - 0.5) * _BreathStrength;
+                half depthFade = CalculateDepthFade(IN.screenPosition, IN.positionWS);
+                half edgeFade = CalculateEdgeFade(IN.uv, edgeNoise);
+
+                half fogShape = lerp(1.0, puffMask, _NoiseStrength);
+                half alpha = baseAlpha * fogShape * breath * depthFade * edgeFade * _BaseColor.a * _Alpha;
+                half4 color = half4(_BaseColor.rgb, alpha);
+                return color;
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Materials/Field/SH_Fog.shader.meta
+++ b/Assets/Materials/Field/SH_Fog.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e60948de9ba6b404295a6b47e7b45b67
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
暗い森の地表付近に配置できる、URP向けの局所フォグ用シェーダーとマテリアルを追加しました。

## 変更内容
- `SH_Fog.shader` を追加し、テクスチャ未設定でも白い半透明板になりにくい手続き型ノイズのフォグ表現を実装
- `M_Fog.mat` を追加し、暗い青緑の色味、境界フェード、自然な流れ、揺らぎの初期値を設定

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #361

## その他 (懸念点・共有事項)
- `DepthFade` は `SampleSceneDepth` を使うため、URP Asset / Renderer 側の Depth Texture 設定によって見え方が変わる可能性があります。
- `dotnet format CreatorKousien.sln --verify-no-changes` は既存C#ファイルの整形差分で失敗しました。今回追加した対象は shader/material/meta の4ファイルのみです。
- `dotnet format whitespace Assets --verify-no-changes` は、この環境では `Assets` がMSBuild workspaceではないため実行エラーになりました。
- Unity Editorでプロジェクトが開かれているため、batchmodeでのシェーダーインポート検証は実施していません。Editor上のReimport / Game View確認をお願いします。

### 実行した確認
- `git diff --cached --name-only`
- `git diff --cached --stat`
- PowerShellによる `.meta` 欠落チェック
- `SH_Fog.shader` の改行コード確認（BareLF/BareCRなし）
- `M_Fog.mat` の Shader GUID が `SH_Fog.shader.meta` と一致することを確認
