### PR TITLE
[#427] 敵撃破時にひっくり返る演出が再生されない不具合の修正

### DIFF
--- a/Assets/Scripts/Core/Enemy/EnemyBodyController.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyBodyController.cs
@@ -26,7 +26,7 @@ namespace Game.Core.Enemy
         float _elapsedTime;
         Quaternion _startRot;
 
-        private void OnEnable()
+        private void Start()
         {
             var controller = GetComponentInParent<EnemyController>();
             if (controller != null)
@@ -35,7 +35,7 @@ namespace Game.Core.Enemy
             }
         }
 
-        private void OnDisable()
+        private void OnDestroy()
         {
             var controller = GetComponentInParent<EnemyController>();
             if (controller != null)


### PR DESCRIPTION
## 概要
敵撃破時にひっくり返るダウン演出が正しく再生されない不具合を修正しました。

## 変更内容
- `EnemyBodyController.cs` のイベント購読タイミングを `OnEnable` / `OnDisable` から `Start` / `OnDestroy` に変更し、動的生成時の親コンポーネント取得漏れを解消。

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [x] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #427
