### PR TITLE
[#465] BOSSとステージ蔦ギミックを再設計する

### DIFF
--- a/Assets/Game/Enemy/SO_Boss_JackFlower.asset
+++ b/Assets/Game/Enemy/SO_Boss_JackFlower.asset
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c359e2404c41384c91cd27762a269b0, type: 3}
+  m_Name: SO_Boss_JackFlower
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.EnemyDefinition
+  EnemyId: Enemy_01
+  IsBoss: 1
+  EnemyBody: {fileID: 8621798176936029137, guid: e5b17b09730b832428c6ba51d7475246, type: 3}
+  MaxHp: 300
+  ExpRate: 1
+  DownDuration: 5
+  HasBarrier: 0
+  MaxGauge: 100
+  BarrierBody: {fileID: 0}
+  barrierBreakMaxLossRate: 0.7
+  AttackPower: 5
+  Attackinterval: 5
+  HealRegenWaitTime: 7
+  HealPower: 30
+  RiseDuration: 30
+  DropDuration: 1
+  BarrierBreakDuration: 0.5
+  DamageDropDuration: 0.2
+  RiseCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  DropCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  BarrierBreakCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  DamageDropCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  BreakDropDistance: 0.2
+  DamageDropDistance: 0.015

--- a/Assets/Game/Enemy/SO_Boss_JackFlower.asset.meta
+++ b/Assets/Game/Enemy/SO_Boss_JackFlower.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d78bca46e2c39648841f11362a49081
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Spawner/EnemySpawnerDefinition.asset
+++ b/Assets/Game/Spawner/EnemySpawnerDefinition.asset
@@ -15,6 +15,13 @@ MonoBehaviour:
   _waveDatas:
   - _hpRate: 1
     _barrierRate: 1
+    _spawnInterval: 1
+    _spawnEnemies:
+    - {fileID: 11400000, guid: 5d78bca46e2c39648841f11362a49081, type: 2}
+    _maxAliveEnemies: 3
+    _minDistanceFromOtherEnemies: 5
+  - _hpRate: 1
+    _barrierRate: 1
     _spawnInterval: 3
     _spawnEnemies:
     - {fileID: 11400000, guid: 4cb55c9a8a363064c9bf094f77b06186, type: 2}

--- a/Assets/Resources/Models/Boss.meta
+++ b/Assets/Resources/Models/Boss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33606c45332e3234591c62a9d439a72c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant.fbx
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0035d624eaba55469e167d5c0b76b982a87f56608e6062f79c53e19f5639051
+size 206560

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant.fbx.meta
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant.fbx.meta
@@ -1,0 +1,110 @@
+fileFormatVersion: 2
+guid: 1a62e08bcca71464ea945fb82154c709
+ModelImporter:
+  serializedVersion: 24200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    generateMeshLods: 0
+    meshLodGenerationFlags: 0
+    maximumMeshLod: -1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant_Break.fbx
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant_Break.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10075a91660b1a3b428c7c8f3f7df5e3489c583dd03ecaad39d5e8a336dd649e
+size 495600

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant_Break.fbx.meta
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant_Break.fbx.meta
@@ -1,0 +1,139 @@
+fileFormatVersion: 2
+guid: a00cea9766bdd5b418fa51b7cefb2c73
+ModelImporter:
+  serializedVersion: 24200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations:
+    - serializedVersion: 16
+      name: Take 001
+      takeName: Take 001
+      internalID: 1827226128182048838
+      firstFrame: 0
+      lastFrame: 30
+      wrapMode: 0
+      orientationOffsetY: 0
+      level: 0
+      cycleOffset: 0
+      loop: 0
+      hasAdditiveReferencePose: 0
+      loopTime: 1
+      loopBlend: 0
+      loopBlendOrientation: 0
+      loopBlendPositionY: 0
+      loopBlendPositionXZ: 0
+      keepOriginalOrientation: 0
+      keepOriginalPositionY: 1
+      keepOriginalPositionXZ: 0
+      heightFromFeet: 0
+      mirror: 0
+      bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+      curves: []
+      events: []
+      transformMask: []
+      maskType: 3
+      maskSource: {instanceID: 0}
+      additiveReferencePoseFrame: 0
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    generateMeshLods: 0
+    meshLodGenerationFlags: 0
+    maximumMeshLod: -1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant_Climb.fbx
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant_Climb.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25664d5f935d41d6e23fe5d23048cbc47d6e431516bab268bd12ca912c682d5b
+size 503024

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant_Climb.fbx.meta
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant_Climb.fbx.meta
@@ -1,0 +1,139 @@
+fileFormatVersion: 2
+guid: 5ac45b5f489eeb54bbf9e165366682c6
+ModelImporter:
+  serializedVersion: 24200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations:
+    - serializedVersion: 16
+      name: Take 001
+      takeName: Take 001
+      internalID: 1827226128182048838
+      firstFrame: 0
+      lastFrame: 30
+      wrapMode: 0
+      orientationOffsetY: 0
+      level: 0
+      cycleOffset: 0
+      loop: 0
+      hasAdditiveReferencePose: 0
+      loopTime: 1
+      loopBlend: 0
+      loopBlendOrientation: 0
+      loopBlendPositionY: 0
+      loopBlendPositionXZ: 0
+      keepOriginalOrientation: 0
+      keepOriginalPositionY: 1
+      keepOriginalPositionXZ: 0
+      heightFromFeet: 0
+      mirror: 0
+      bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+      curves: []
+      events: []
+      transformMask: []
+      maskType: 3
+      maskSource: {instanceID: 0}
+      additiveReferencePoseFrame: 0
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    generateMeshLods: 0
+    meshLodGenerationFlags: 0
+    maximumMeshLod: -1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant_Vine.fbx
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant_Vine.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb1fd219de5a143ba5c92dad66a6e772aee46d86f74662c8eb43cedd2d9f4519
+size 101232

--- a/Assets/Resources/Models/Boss/ANIM_BossPlant_Vine.fbx.meta
+++ b/Assets/Resources/Models/Boss/ANIM_BossPlant_Vine.fbx.meta
@@ -1,0 +1,110 @@
+fileFormatVersion: 2
+guid: 14507c8fbc8d4134c93d4c6095361175
+ModelImporter:
+  serializedVersion: 24200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    generateMeshLods: 0
+    meshLodGenerationFlags: 0
+    maximumMeshLod: -1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/Boss.prefab
+++ b/Assets/Resources/Models/Boss/Boss.prefab
@@ -1,0 +1,223 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8621798176936029137
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6164063175633468371}
+  - component: {fileID: 8497063588713132127}
+  - component: {fileID: 38785937057867740}
+  - component: {fileID: 2721769458615408527}
+  - component: {fileID: 7629966135112345678}
+  - component: {fileID: 4566247045174569554}
+  m_Layer: 0
+  m_Name: Boss
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6164063175633468371
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621798176936029137}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0}
+  m_LocalScale: {x: 60, y: 60, z: 60}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 8771055241699420702}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &8497063588713132127
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621798176936029137}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 4ff4084c401060741839594c858512f0, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &38785937057867740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621798176936029137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd02829c183a64e4584003d87d9d6f89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.JackFlowerBossVineSpawner
+  _vinePrefab: {fileID: 2910390922885167427, guid: 960488377f47bd2498e1b2b7c76002cd, type: 3}
+  _spawnInterval: 4
+  _maxActiveVines: 2
+  _vineExtendSpeed: 6
+  _vineHitBackDistance: 1.5
+  _vineMaxShrinkDistance: 4.5
+  _vineTargetOverride: {fileID: 0}
+  _vineTargetOffset: {x: 0, y: 0, z: -6}
+  _leftAnchorTag: Field_LeftFront
+  _rightAnchorTag: Field_RightFront
+  _cliffAnchorTag: Floor
+  _spawnBelowCliffSurface: 1
+  _startDepthOffset: 0.5
+  _cliffEdgeInset: 1.5
+  _leftSpawnOffset: {x: 0, y: 0, z: -6}
+  _rightSpawnOffset: {x: 0, y: 0, z: -6}
+  _collectibleCount: 12
+--- !u!114 &2721769458615408527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621798176936029137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71fa6540b0f3d294abbeac213ab6ae93, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.EnemyBodyController
+  _animator: {fileID: 8497063588713132127}
+  _maxHitAnimationTime: 0
+  _addHitAnimationTime: 0
+  _dropDuration: 1
+  _dropRot: {x: 0, y: 0, z: 0}
+--- !u!114 &7629966135112345678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621798176936029137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fdae53f678ed0a44a2b6c7cd11fac5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.EnemyHitReceiver
+  _minimumHitSpeed: 0.75
+  _bodyDamageMultiplier: 2.5
+  _despawnItemOnHit: 0
+--- !u!136 &4566247045174569554
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621798176936029137}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.1
+  m_Height: 0.36373797
+  m_Direction: 1
+  m_Center: {x: 0, y: -0.07577147, z: -0.12}
+--- !u!1001 &9093811324922564085
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6164063175633468371}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+      propertyPath: m_Name
+      value: ANIM_BossPlant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+--- !u!4 &8771055241699420702 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1a62e08bcca71464ea945fb82154c709, type: 3}
+  m_PrefabInstance: {fileID: 9093811324922564085}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Models/Boss/Boss.prefab.meta
+++ b/Assets/Resources/Models/Boss/Boss.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e5b17b09730b832428c6ba51d7475246
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/Green.mat
+++ b/Assets/Resources/Models/Boss/Green.mat
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6493519446995703123
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Editor::UnityEditor.Rendering.Universal.AssetVersion
+  version: 10
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Green
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.14901961, g: 0.20000002, b: 0.14901961, a: 1}
+    - _Color: {r: 0.14901957, g: 0.19999999, b: 0.14901957, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Assets/Resources/Models/Boss/Green.mat.meta
+++ b/Assets/Resources/Models/Boss/Green.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c95bfb4ade1ea8449c975c5908e7deb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/JackFlowerBossAnimator.controller
+++ b/Assets/Resources/Models/Boss/JackFlowerBossAnimator.controller
@@ -1,0 +1,168 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-7453566183083025812
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsClimbring
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: OnHit
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6223725970634039076}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-6223725970634039076
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Clim
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: 5ac45b5f489eeb54bbf9e165366682c6, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-3726430061885707529
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Hit
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: a00cea9766bdd5b418fa51b7cefb2c73, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-2793245578993961551
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: OnHit
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -3726430061885707529}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1107 &-2333667364871905990
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -3726430061885707529}
+    m_Position: {x: 390, y: -60, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -6223725970634039076}
+    m_Position: {x: 390, y: 220, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions:
+  - {fileID: -7453566183083025812}
+  - {fileID: -2793245578993961551}
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 40, y: -170, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -3726430061885707529}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: JackFlowerBossAnimator
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: IsClimbring
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: OnHit
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -2333667364871905990}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/Assets/Resources/Models/Boss/JackFlowerBossAnimator.controller.meta
+++ b/Assets/Resources/Models/Boss/JackFlowerBossAnimator.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4ff4084c401060741839594c858512f0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/JackFlowerVine .prefab
+++ b/Assets/Resources/Models/Boss/JackFlowerVine .prefab
@@ -1,0 +1,129 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2910390922885167427
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7643405064784780732}
+  - component: {fileID: 5077273732444892515}
+  - component: {fileID: 6737821164081474647}
+  - component: {fileID: 244242338065464230}
+  - component: {fileID: 1636490343873929241}
+  m_Layer: 9
+  m_Name: 'JackFlowerVine '
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7643405064784780732
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 14.03761, y: 0, z: 15.6187}
+  m_LocalScale: {x: 1, y: 5.16, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5077273732444892515
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6737821164081474647
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5c95bfb4ade1ea8449c975c5908e7deb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &244242338065464230
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1636490343873929241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c53e74cea52b4474d9622dc315e0871f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.JackFlowerVine

--- a/Assets/Resources/Models/Boss/JackFlowerVine .prefab.meta
+++ b/Assets/Resources/Models/Boss/JackFlowerVine .prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 960488377f47bd2498e1b2b7c76002cd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Models/Boss/StageCollectibleVine.prefab
+++ b/Assets/Resources/Models/Boss/StageCollectibleVine.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2910390922885167427
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7643405064784780732}
+  - component: {fileID: 5077273732444892515}
+  - component: {fileID: 6737821164081474647}
+  - component: {fileID: 244242338065464230}
+  - component: {fileID: 1636490343873929241}
+  m_Layer: 9
+  m_Name: StageCollectibleVine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7643405064784780732
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 2
+  m_GameObject: {fileID: 2910390922885167427}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5077273732444892515
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6737821164081474647
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5c95bfb4ade1ea8449c975c5908e7deb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &244242338065464230
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1636490343873929241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2910390922885167427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c9b9cf79d5c4e0ba9b2fd0b78cf85cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.StageCollectibleVine

--- a/Assets/Resources/Models/Boss/StageCollectibleVine.prefab.meta
+++ b/Assets/Resources/Models/Boss/StageCollectibleVine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c30f1798c0e8488d8e6c8a73f1afc3f0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Stage.unity
+++ b/Assets/Scenes/Stage.unity
@@ -205239,6 +205239,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 931832926}
+  - component: {fileID: 334455667}
   m_Layer: 0
   m_Name: StageRoot
   m_TagString: Untagged
@@ -205270,6 +205271,29 @@ Transform:
   - {fileID: 524982895}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &334455667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 931832925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f4f8d4cf0ae4d3a9f1b44f7e76f8f4c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.StageCollectibleVineSpawner
+  _vinePrefab: {fileID: 2910390922885167427, guid: c30f1798c0e8488d8e6c8a73f1afc3f0, type: 3}
+  _spawnInterval: 8
+  _maxActiveVines: 6
+  _edgeInset: 2
+  _spawnOffset: {x: 0, y: 1.5, z: 0}
+  _leftFrontAnchorTag: Field_LeftFront
+  _rightFrontAnchorTag: Field_RightFront
+  _leftBackAnchorTag: Field_LeftBack
+  _rightBackAnchorTag: Field_RightBack
+  _centerAnchorTag: Field_Center
+  _collectibleCount: 12
 --- !u!1 &934694663
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyController.cs
@@ -224,6 +224,14 @@ namespace Game.Core.Enemy
             if (_stateManager.CurrentState == EnemyState.OverHit) _holdCounter.UpdateHold();
         }
 
+        /// <summary>
+        /// ギミックから即時に防衛ライン攻撃を発生させる。
+        /// </summary>
+        public void AttackNow()
+        {
+            _enemyAttack?.AttackNow();
+        }
+
         // ─────────────────────────────────────────
         // イベント受信
         // ─────────────────────────────────────────
@@ -423,9 +431,14 @@ namespace Game.Core.Enemy
 
         public void SetActiv(bool activ) => _isActiv = activ;
 
-        void Attack()
+        public void AttackNow()
         {
             EventBus.Publish(new RuleBarrierAttackEvent(_attackPower));
+        }
+
+        private void Attack()
+        {
+            AttackNow();
         }
     }
 

--- a/Assets/Scripts/Core/Enemy/EnemyDefinition.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyDefinition.cs
@@ -14,6 +14,9 @@ namespace Game.Core.Enemy
         [Tooltip("ゲームシーン内でユニークな文字列。EventBusのフィルタリングに使用。")]
         public string EnemyId = "Enemy_01";
 
+        [Tooltip("有効にするとフィールド中央アンカーから出現するボスとして扱う。")]
+        public bool IsBoss = false;
+
         [Header("敵実体オブジェクト")]
         [Tooltip("敵の実体として生成されるオブジェクト、敵のプレファブを設定する")]
         public GameObject EnemyBody;

--- a/Assets/Scripts/Core/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Core/Enemy/EnemySpawner.cs
@@ -6,8 +6,8 @@
  * 更新履歴：
  * 5/30: 敵生成時、重なってスポーンしないように修正しました - 浅野
  *       自動で敵がスポーンするようにしました。
- *       
- *       
+ *
+ *
  * 6/24: データをSO化した！
  *       生成方法を空のゲームオブジェクトを出してコンポーネントつけて
  *       子オブジェクトに当たり判定用オブジェクトを生成する形に変更した！
@@ -15,6 +15,8 @@
  * 
  * 7/02: ゲームループ (バトル -> ローグライク) 対応の為、単一ウェーブ管理型へリファクタリング。
  *       ウェーブ進行管理を GameProgressionManager へ分離。 - Iwai a.k.a. ZEUS
+ *
+ * 7/11: ボスの追加 - Y_Akira
  */
 
 using System.Collections;
@@ -139,8 +141,14 @@ namespace Game.Core.Enemy
             EnemyDefinition definition = _currentSpawnEnemies[0];
             _currentSpawnEnemies.RemoveAt(0);
 
+            if (definition == null)
+            {
+                Debug.LogError("[EnemySpawner] スポーン対象の EnemyDefinition が null です。ウェーブ設定アセットを確認してください。");
+                return;
+            }
+
             // 目標位置計算
-            if (!TryGetSpawnTargetPosition(out Vector3 targetPos))
+            if (!TryGetSpawnTargetPosition(definition.IsBoss, out Vector3 targetPos))
             {
                 Debug.LogWarning("[EnemySpawner] 敵のスポーンに失敗しました。既存の敵と十分な距離を取れる位置が見つかりませんでした。");
                 return;
@@ -158,28 +166,21 @@ namespace Game.Core.Enemy
                 barrier = Instantiate(definition.BarrierBody, enemyGo.transform);
             }
 
-
-            // コンポーネントをアタッチ
             EnemyController controller = enemyGo.AddComponent<EnemyController>();
             enemyGo.AddComponent<EnemyRising>();
             enemyGo.AddComponent<EnemyWorldStatusView>();
 
             if (!body.TryGetComponent(out EnemyBodyController bodyController))
             {
-                Debug.LogWarning("[EnemySpawner] EnemyHitReceiver が付与されていないため生成を中止します。", body);
-                // Bodyが正しく生成されなかった場合親ごと削除
+                Debug.LogWarning("[EnemySpawner] EnemyBodyController が付与されていないため生成を中止します。", body);
                 Destroy(enemyGo);
                 return;
             }
 
-            // 生成した敵を初期化
             EnemyController.SpawnSummary spawnSummary = new EnemyController.SpawnSummary(targetPos, _undergroundOffset, _currentHpRate, _currentBarrierRate);
             string enemyId = controller.Initialize(definition, spawnSummary);
-
-            // ボディを初期化
             bodyController.Initialize(enemyId);
 
-            // バリアが存在する場合初期化
             if (definition.HasBarrier && barrier != null)
             {
                 controller.BarrierInitialize(definition, spawnSummary, barrier);
@@ -240,8 +241,13 @@ namespace Game.Core.Enemy
         /// </summary>
         /// <param name="targetPos">ターゲット位置</param>
         /// <returns>見つかったらtrueを返す</returns>
-        private bool TryGetSpawnTargetPosition(out Vector3 targetPos)
+        private bool TryGetSpawnTargetPosition(bool isBoss, out Vector3 targetPos)
         {
+            if (isBoss && TryGetCenterAnchorPosition(out targetPos))
+            {
+                return true;
+            }
+
             for (int i = 0; i < _maxSpawnPositionAttempts; i++)
             {
                 targetPos = CreateRandomTargetPosition();
@@ -250,6 +256,30 @@ namespace Game.Core.Enemy
                 {
                     return true;
                 }
+            }
+
+            targetPos = default;
+            return false;
+        }
+
+        private bool TryGetCenterAnchorPosition(out Vector3 targetPos)
+        {
+            try
+            {
+                GameObject center = GameObject.FindGameObjectWithTag("Field_Center");
+                if (center != null)
+                {
+                    Vector3 centerPosition = center.transform.position;
+                    Vector3 spawnBasePosition = _spawnBasePoint != null
+                        ? _spawnBasePoint.position
+                        : centerPosition;
+                    targetPos = new Vector3(centerPosition.x, spawnBasePosition.y, spawnBasePosition.z + 5.0f);
+                    return true;
+                }
+            }
+            catch (UnityException)
+            {
+                // タグが存在しない旧シーンでは通常のスポーンへフォールバックする。
             }
 
             targetPos = default;

--- a/Assets/Scripts/Core/Enemy/JackFlowerBossController.cs
+++ b/Assets/Scripts/Core/Enemy/JackFlowerBossController.cs
@@ -1,0 +1,214 @@
+using System.Collections;
+using System.Collections.Generic;
+using Game.Gameplay.Collectibles;
+using Game.Gameplay.Stage;
+using UnityEngine;
+// ================================================================================
+// File         : JackFlowerBine.cs
+// Author       : Y_Akira
+//
+// Description  : ボスの総合コントローラー。
+// Created      : 2026-07-11
+// ================================================================================
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 崖下の左右からボス本体へ伸びる蔦と、蔦到達時のボス攻撃を管理する。
+    /// </summary>
+    public sealed class JackFlowerBossVineSpawner : MonoBehaviour
+    {
+        [Header("蔦の生成")]
+        [SerializeField] private GameObject _vinePrefab;
+        [SerializeField, Min(0.1f)] private float _spawnInterval = 4f;
+        [SerializeField, Min(1)] private int _maxActiveVines = 2;
+        [SerializeField, Min(0.1f)] private float _vineExtendSpeed = 6f;
+        [SerializeField, Min(0.01f)] private float _vineHitBackDistance = 1.5f;
+        [SerializeField, Min(0.01f)] private float _vineMaxShrinkDistance = 4.5f;
+
+        [Header("蔦の到達点")]
+        [SerializeField] private Transform _vineTargetOverride;
+        [SerializeField] private Vector3 _vineTargetOffset;
+
+        [Header("崖下の発生位置")]
+        [SerializeField] private string _leftAnchorTag = "Field_LeftFront";
+        [SerializeField] private string _rightAnchorTag = "Field_RightFront";
+        [SerializeField] private string _cliffAnchorTag = "Floor";
+        [SerializeField, Min(0f)] private float _spawnBelowCliffSurface = 1f;
+        [SerializeField, Min(0f)] private float _startDepthOffset = 0.5f;
+        [SerializeField, Min(0f)] private float _cliffEdgeInset = 1.5f;
+        [SerializeField] private Vector3 _leftSpawnOffset;
+        [SerializeField] private Vector3 _rightSpawnOffset;
+
+        [Header("蔦を壊し切った時のボーナス")]
+        [SerializeField, Min(0)] private int _collectibleCount = 12;
+
+        private readonly List<JackFlowerVine> _activeVines = new();
+        private EnemyController _enemyController;
+        private EnemyRising _rising;
+        private CollectibleSpawner _collectibleSpawner;
+        private Animator _bossAnimator;
+        private Coroutine _spawnCoroutine;
+        private bool _spawnLeftNext = true;
+
+        private void Awake()
+        {
+            _enemyController = GetComponentInParent<EnemyController>();
+            _rising = GetComponentInParent<EnemyRising>();
+            _bossAnimator = GetComponentInParent<Animator>();
+        }
+
+        private void OnEnable()
+        {
+            _spawnCoroutine = StartCoroutine(SpawnRoutine());
+        }
+
+        private void OnDisable()
+        {
+            if (_spawnCoroutine != null)
+            {
+                StopCoroutine(_spawnCoroutine);
+                _spawnCoroutine = null;
+            }
+        }
+
+        private IEnumerator SpawnRoutine()
+        {
+            while (enabled)
+            {
+                SpawnVine();
+                yield return new WaitForSeconds(_spawnInterval);
+            }
+        }
+
+        private void SpawnVine()
+        {
+            _activeVines.RemoveAll(vine => vine == null);
+            if (_vinePrefab == null || _activeVines.Count >= _maxActiveVines)
+            {
+                return;
+            }
+
+            bool spawnLeft = _spawnLeftNext;
+            Transform anchor = FindAnchor(spawnLeft ? _leftAnchorTag : _rightAnchorTag);
+            _spawnLeftNext = !_spawnLeftNext;
+            if (anchor == null)
+            {
+                Debug.LogWarning("[JackFlowerBossVineSpawner] 左右の崖アンカーが見つからないため、蔦を生成できません。", this);
+                return;
+            }
+
+            Vector3 startPosition = anchor.position;
+            if (TryGetCliffBounds(out Bounds cliffBounds))
+            {
+                startPosition.y = cliffBounds.max.y - _spawnBelowCliffSurface;
+                startPosition.z = transform.position.z - _startDepthOffset;
+            }
+            else
+            {
+                Transform cliffAnchor = FindAnchor(_cliffAnchorTag);
+                if (cliffAnchor != null)
+                {
+                    startPosition.y = cliffAnchor.position.y - _spawnBelowCliffSurface;
+                    startPosition.z = transform.position.z - _startDepthOffset;
+                }
+            }
+            startPosition.x = GetCliffEdgeX(spawnLeft, anchor.position.x);
+            startPosition += spawnLeft ? _leftSpawnOffset : _rightSpawnOffset;
+            GameObject vineObject = Instantiate(_vinePrefab, startPosition, Quaternion.identity);
+            if (!vineObject.TryGetComponent(out JackFlowerVine vine))
+            {
+                Destroy(vineObject);
+                return;
+            }
+
+            vine.Initialize(this, startPosition, _vineTargetOverride != null ? _vineTargetOverride : transform,
+                _vineTargetOffset, _vineExtendSpeed, _vineHitBackDistance, _vineMaxShrinkDistance);
+            _activeVines.Add(vine);
+        }
+
+        private float GetCliffEdgeX(bool left, float fallback)
+        {
+            if (!TryGetCliffBounds(out Bounds bounds))
+            {
+                return fallback;
+            }
+
+            return left
+                ? bounds.min.x + _cliffEdgeInset
+                : bounds.max.x - _cliffEdgeInset;
+        }
+
+        private bool TryGetCliffBounds(out Bounds bounds)
+        {
+            CliffGrassBlendMesh cliff = FindFirstObjectByType<CliffGrassBlendMesh>();
+            Renderer renderer = cliff != null ? cliff.GetComponent<Renderer>() : null;
+            if (renderer != null)
+            {
+                bounds = renderer.bounds;
+                return true;
+            }
+
+            bounds = default;
+            return false;
+        }
+
+        private Transform FindAnchor(string tag)
+        {
+            try
+            {
+                GameObject anchor = GameObject.FindGameObjectWithTag(tag);
+                return anchor != null ? anchor.transform : null;
+            }
+            catch (UnityException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// パンチが蔦に当たった時に呼ばれる。
+        /// </summary>
+        public void HandleVinePunched(JackFlowerVine vine)
+        {
+            if (vine != null)
+            {
+                vine.ApplyHit();
+            }
+        }
+
+        /// <summary>
+        /// 蔦がボス本体へ到達した時に、攻撃モーションと防衛ライン攻撃を発生させる。
+        /// </summary>
+        public void HandleVineReached(JackFlowerVine vine)
+        {
+            if (vine == null)
+            {
+                return;
+            }
+
+            _enemyController ??= GetComponentInParent<EnemyController>();
+            _bossAnimator ??= GetComponentInParent<Animator>();
+            _bossAnimator?.Play("Base Layer.Hit", 0, 0f);
+            _enemyController?.AttackNow();
+        }
+
+        /// <summary>
+        /// 蔦を最大まで縮ませた時のボーナス落ちものを生成する。
+        /// </summary>
+        public void HandleVineFullyShrunk(JackFlowerVine vine, Vector3 position)
+        {
+            _activeVines.Remove(vine);
+            _rising ??= GetComponentInParent<EnemyRising>();
+            _rising?.DamageDrop(transform);
+
+            _collectibleSpawner ??= FindFirstObjectByType<CollectibleSpawner>();
+            if (_collectibleSpawner == null)
+            {
+                Debug.LogWarning("[JackFlowerBossVineSpawner] CollectibleSpawner が見つからないため、ボーナスを生成できません。", this);
+                return;
+            }
+
+            _collectibleSpawner.SpawnCollectiblesAt(position, _collectibleCount);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/JackFlowerBossController.cs.meta
+++ b/Assets/Scripts/Core/Enemy/JackFlowerBossController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd02829c183a64e4584003d87d9d6f89

--- a/Assets/Scripts/Core/Enemy/JackFlowerVine.cs
+++ b/Assets/Scripts/Core/Enemy/JackFlowerVine.cs
@@ -1,0 +1,128 @@
+using Game.Gameplay.Collectibles;
+using UnityEngine;
+// ================================================================================
+// File         : JackFlowerBine.cs
+// Author       : Y_Akira
+//
+// Description  : ボスの左右伸縮ツタ生成コントローラー。
+// Created      : 2026-07-11
+// ================================================================================
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// 崖下からボスへ伸び、パンチでヒットバックする蔦。
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public sealed class JackFlowerVine : MonoBehaviour, ICrystalBreakable
+    {
+        private JackFlowerBossVineSpawner _owner;
+        private Transform _target;
+        private Vector3 _targetOffset;
+        private Vector3 _startPosition;
+        private float _extendSpeed;
+        private float _hitBackDistance;
+        private float _maxShrinkDistance;
+        private float _currentLength;
+        private float _shrinkDistance;
+        private bool _hasReached;
+        private bool _isBroken;
+
+        public void Initialize(
+            JackFlowerBossVineSpawner owner,
+            Vector3 startPosition,
+            Transform target,
+            Vector3 targetOffset,
+            float extendSpeed,
+            float hitBackDistance,
+            float maxShrinkDistance)
+        {
+            _owner = owner;
+            _target = target;
+            _targetOffset = targetOffset;
+            _startPosition = startPosition;
+            _extendSpeed = extendSpeed;
+            _hitBackDistance = hitBackDistance;
+            _maxShrinkDistance = maxShrinkDistance;
+            _currentLength = 0f;
+            UpdateVisual();
+        }
+
+        private void Update()
+        {
+            if (_isBroken || _target == null)
+            {
+                return;
+            }
+
+            float maxLength = Vector3.Distance(_startPosition, GetTargetPosition());
+            _currentLength = Mathf.MoveTowards(_currentLength, maxLength, _extendSpeed * Time.deltaTime);
+            UpdateVisual();
+
+            if (!_hasReached && maxLength > 0.01f && _currentLength >= maxLength - 0.05f)
+            {
+                _hasReached = true;
+                _owner?.HandleVineReached(this);
+            }
+        }
+
+        /// <summary>
+        /// パンチで蔦を縮ませる。縮み量は蓄積し、最大値で破壊される。
+        /// </summary>
+        public void ApplyHit()
+        {
+            if (_isBroken)
+            {
+                return;
+            }
+
+            _shrinkDistance += _hitBackDistance;
+            if (_shrinkDistance >= _maxShrinkDistance)
+            {
+                _isBroken = true;
+                _owner?.HandleVineFullyShrunk(this, transform.position);
+                Destroy(gameObject);
+                return;
+            }
+
+            _currentLength = Mathf.Max(0f, _currentLength - _hitBackDistance);
+            _hasReached = false;
+            UpdateVisual();
+        }
+
+        /// <summary>
+        /// プレイヤーのパンチシステムから呼ばれる共通入口。
+        /// </summary>
+        public void Break(Vector3 hitPoint, Vector3 hitDirection)
+        {
+            _owner?.HandleVinePunched(this);
+        }
+
+        private void UpdateVisual()
+        {
+            if (_target == null)
+            {
+                return;
+            }
+
+            Vector3 delta = GetTargetPosition() - _startPosition;
+            float maxLength = delta.magnitude;
+            if (maxLength <= 0.01f)
+            {
+                return;
+            }
+
+            Vector3 direction = delta / maxLength;
+            transform.position = _startPosition + direction * (_currentLength * 0.5f);
+            transform.rotation = Quaternion.FromToRotation(Vector3.up, direction);
+
+            // 蔦プレハブを現在長に合わせて伸縮する。
+            Vector3 scale = transform.localScale;
+            transform.localScale = new Vector3(scale.x, Mathf.Max(0.01f, _currentLength * 0.5f), scale.z);
+        }
+
+        private Vector3 GetTargetPosition()
+        {
+            return _target.position + _targetOffset;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/JackFlowerVine.cs.meta
+++ b/Assets/Scripts/Core/Enemy/JackFlowerVine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c53e74cea52b4474d9622dc315e0871f

--- a/Assets/Scripts/Core/Enemy/StageCollectibleVine.cs
+++ b/Assets/Scripts/Core/Enemy/StageCollectibleVine.cs
@@ -1,0 +1,32 @@
+using Game.Gameplay.Collectibles;
+using UnityEngine;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// ステージ上で殴ると消え、収集物を排出する蔦。
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public sealed class StageCollectibleVine : MonoBehaviour, ICrystalBreakable
+    {
+        private StageCollectibleVineSpawner _owner;
+        private bool _broken;
+
+        public void Initialize(StageCollectibleVineSpawner owner)
+        {
+            _owner = owner;
+        }
+
+        public void Break(Vector3 hitPoint, Vector3 hitDirection)
+        {
+            if (_broken)
+            {
+                return;
+            }
+
+            _broken = true;
+            _owner?.HandleVineBroken(this, transform.position);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/StageCollectibleVine.cs.meta
+++ b/Assets/Scripts/Core/Enemy/StageCollectibleVine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c9b9cf79d5c4e0ba9b2fd0b78cf85cf

--- a/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs
+++ b/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs
@@ -1,0 +1,150 @@
+using System.Collections;
+using System.Collections.Generic;
+using Game.Gameplay.Collectibles;
+using UnityEngine;
+
+namespace Game.Core.Enemy
+{
+    /// <summary>
+    /// ステージアンカーの範囲内に、収集物を排出する蔦を生成する。
+    /// </summary>
+    public sealed class StageCollectibleVineSpawner : MonoBehaviour
+    {
+        [Header("蔦の生成")]
+        [SerializeField] private GameObject _vinePrefab;
+        [SerializeField, Min(0.1f)] private float _spawnInterval = 8f;
+        [SerializeField, Min(1)] private int _maxActiveVines = 6;
+        [SerializeField, Min(0f)] private float _edgeInset = 2f;
+        [SerializeField] private Vector3 _spawnOffset;
+
+        [Header("アンカー")]
+        [SerializeField] private string _leftFrontAnchorTag = "Field_LeftFront";
+        [SerializeField] private string _rightFrontAnchorTag = "Field_RightFront";
+        [SerializeField] private string _leftBackAnchorTag = "Field_LeftBack";
+        [SerializeField] private string _rightBackAnchorTag = "Field_RightBack";
+        [SerializeField] private string _centerAnchorTag = "Field_Center";
+
+        [Header("収集物")]
+        [SerializeField, Min(0)] private int _collectibleCount = 12;
+
+        private readonly List<StageCollectibleVine> _activeVines = new();
+        private CollectibleSpawner _collectibleSpawner;
+        private Coroutine _spawnCoroutine;
+
+        private void OnEnable()
+        {
+            _spawnCoroutine = StartCoroutine(SpawnRoutine());
+        }
+
+        private void OnDisable()
+        {
+            if (_spawnCoroutine != null)
+            {
+                StopCoroutine(_spawnCoroutine);
+                _spawnCoroutine = null;
+            }
+        }
+
+        private IEnumerator SpawnRoutine()
+        {
+            while (enabled)
+            {
+                SpawnVine();
+                yield return new WaitForSeconds(_spawnInterval);
+            }
+        }
+
+        private void SpawnVine()
+        {
+            _activeVines.RemoveAll(vine => vine == null);
+            if (_vinePrefab == null || _activeVines.Count >= _maxActiveVines)
+            {
+                return;
+            }
+
+            if (!TryGetStageBounds(out Bounds bounds))
+            {
+                return;
+            }
+
+            Vector3 position = new Vector3(
+                Random.Range(bounds.min.x + _edgeInset, bounds.max.x - _edgeInset),
+                bounds.max.y,
+                Random.Range(bounds.min.z + _edgeInset, bounds.max.z - _edgeInset));
+            position += _spawnOffset;
+
+            GameObject vineObject = Instantiate(_vinePrefab, position, Quaternion.identity);
+            if (!vineObject.TryGetComponent(out StageCollectibleVine vine))
+            {
+                Destroy(vineObject);
+                return;
+            }
+
+            vine.Initialize(this);
+            _activeVines.Add(vine);
+        }
+
+        private bool TryGetStageBounds(out Bounds bounds)
+        {
+            Transform[] anchors = new[]
+            {
+                FindAnchor(_leftFrontAnchorTag),
+                FindAnchor(_rightFrontAnchorTag),
+                FindAnchor(_leftBackAnchorTag),
+                FindAnchor(_rightBackAnchorTag)
+            };
+
+            bounds = default;
+            bool hasAnchor = false;
+            foreach (Transform anchor in anchors)
+            {
+                if (anchor == null)
+                {
+                    continue;
+                }
+
+                if (!hasAnchor)
+                {
+                    bounds = new Bounds(anchor.position, Vector3.zero);
+                    hasAnchor = true;
+                }
+                else
+                {
+                    bounds.Encapsulate(anchor.position);
+                }
+            }
+
+            if (!hasAnchor)
+            {
+                return false;
+            }
+
+            Transform center = FindAnchor(_centerAnchorTag);
+            float surfaceY = center != null ? center.position.y : bounds.max.y;
+            bounds.SetMinMax(
+                new Vector3(bounds.min.x, surfaceY, bounds.min.z),
+                new Vector3(bounds.max.x, surfaceY, bounds.max.z));
+            return true;
+        }
+
+        public void HandleVineBroken(StageCollectibleVine vine, Vector3 position)
+        {
+            _activeVines.Remove(vine);
+            _collectibleSpawner ??= FindFirstObjectByType<CollectibleSpawner>();
+            _collectibleSpawner?.SpawnCollectiblesAt(position, _collectibleCount);
+        }
+
+        private Transform FindAnchor(string tag)
+        {
+            try
+            {
+                GameObject anchor = GameObject.FindGameObjectWithTag(tag);
+                return anchor != null ? anchor.transform : null;
+            }
+            catch (UnityException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs.meta
+++ b/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f4f8d4cf0ae4d3a9f1b44f7e76f8f4c

--- a/Assets/Scripts/Gameplay/Collectibles/Management/CollectibleSpawner.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/CollectibleSpawner.cs
@@ -40,6 +40,11 @@ namespace Game.Gameplay.Collectibles
         [Tooltip("プレイヤーが触れた時に保持/回収できるか")]
         [SerializeField] private bool _canBeCollectedByPlayer = false;
 
+        [Header("高さ補正")]
+        [Tooltip("指定位置から下方向に地面を探し、地面からこの高さに収集物を出す")]
+        [SerializeField] private float _spawnHeightOffset = 0.5f;
+        [SerializeField] private LayerMask _spawnGroundMask = ~0;
+
         [SerializeField, Tooltip("SubScene連携用SO")]
         private SceneEventChannel _eventChannel;
 
@@ -93,6 +98,52 @@ namespace Game.Gameplay.Collectibles
         }
 
         /// <summary>
+        /// 指定位置を中心にアイテムを生成して、初期速度を与えます。
+        /// </summary>
+        public void SpawnCollectiblesAt(Vector3 position, int count)
+        {
+            if (!CanSpawn())
+            {
+                return;
+            }
+
+            position = GetHeightAdjustedPosition(position);
+            for (int i = 0; i < Mathf.Max(0, count); i++)
+            {
+                SpawnOne(position);
+            }
+        }
+
+        private Vector3 GetHeightAdjustedPosition(Vector3 position)
+        {
+            Vector3 origin = position + Vector3.up * 50f;
+            RaycastHit[] hits = Physics.RaycastAll(origin, Vector3.down, 100f,
+                _spawnGroundMask, QueryTriggerInteraction.Ignore);
+            bool found = false;
+            float groundY = float.MinValue;
+            foreach (RaycastHit hit in hits)
+            {
+                if (hit.collider.CompareTag("Enemy") || hit.collider.CompareTag("Player"))
+                {
+                    continue;
+                }
+
+                if (hit.point.y <= position.y + 0.1f && (!found || hit.point.y > groundY))
+                {
+                    found = true;
+                    groundY = hit.point.y;
+                }
+            }
+
+            if (found)
+            {
+                position.y = groundY + _spawnHeightOffset;
+            }
+
+            return position;
+        }
+
+        /// <summary>
         /// 1個のアイテムを生成し、自由に動く初期速度を与える。
         /// </summary>
         private void SpawnOne()
@@ -102,6 +153,22 @@ namespace Game.Gameplay.Collectibles
             CollectibleObject obj = _pool.Get();
 
             obj.transform.position = area.GetRandomPosition();
+            obj.transform.rotation = Random.rotation;
+            obj.Initialize(data, ReturnToPool, _canBeCollectedByPlayer);
+            obj.SetInitialMotion(CreateInitialVelocity(), Random.insideUnitSphere * Random.Range(2f, 8f));
+
+            _registry.Register(obj);
+        }
+
+        /// <summary>
+        /// 指定位置に1個のアイテムを生成する。
+        /// </summary>
+        private void SpawnOne(Vector3 position)
+        {
+            CollectibleData data = _spawnableData[Random.Range(0, _spawnableData.Length)];
+            CollectibleObject obj = _pool.Get();
+
+            obj.transform.position = position;
             obj.transform.rotation = Random.rotation;
             obj.Initialize(data, ReturnToPool, _canBeCollectedByPlayer);
             obj.SetInitialMotion(CreateInitialVelocity(), Random.insideUnitSphere * Random.Range(2f, 8f));

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - Field_LeftFront
   - Field_RightBack
   - Field_RightFront
+  - Enemy
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## 概要

BOSS戦用の崖蔦と、ステージ上で破壊すると収集物を排出する蔦を分離して実装します。

## 変更内容

- BOSSをフィールド中央アンカー基準でスポーン
- BOSS用蔦を左右の崖からBOSSへ伸長
- BOSS用蔦への攻撃で縮小・再伸長
- BOSS用蔦を最大まで縮ませた時に収集物を排出
- ステージ4隅のアンカー範囲内に蔦をランダム生成
- ステージ蔦をパンチで破壊すると収集物を排出
- ステージ蔦の同時出現数をInspectorで調整（初期値6本）
- 収集物数をInspectorで調整（初期値12個）
- 通常敵スポーンのBOSS判定を追加

## 確認項目 (セルフチェック)

### 💻 実装・品質

- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ

- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue

Closes #465

## その他 (懸念点・共有事項)

- `dotnet build CreatorKousien.sln --no-restore --no-incremental` は成功（0エラー、既存警告20件）。
- Unity EditorでStageシーンと追加Prefabのインポートを確認済み。
- `dotnet format --verify-no-changes` は既存コードの改行・空白差分で失敗したため、自動修正していない。
- PlayModeでのパンチ操作と収集物排出は未確認。
