### PR TITLE
[#473] ボスのツル生成ロジックの調整と最大数の制限

### DIFF
--- a/Assets/Resources/Models/Boss/Boss.prefab
+++ b/Assets/Resources/Models/Boss/Boss.prefab
@@ -73,7 +73,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Game.Core.Enemy.JackFlowerBossVineSpawner
   _vinePrefab: {fileID: 2910390922885167427, guid: 960488377f47bd2498e1b2b7c76002cd, type: 3}
   _spawnInterval: 4
-  _maxActiveVines: 2
+  _maxActiveVines: 1
   _vineExtendSpeed: 6
   _vineHitBackDistance: 1.5
   _vineMaxShrinkDistance: 4.5

--- a/Assets/Scripts/Core/Enemy/EnemyRising.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyRising.cs
@@ -462,5 +462,6 @@ namespace Game.Core.Enemy
             _isStopping = false;
             RestartCoroutine();
         }
+
     }
 }

--- a/Assets/Scripts/Core/Enemy/JackFlowerBossController.cs
+++ b/Assets/Scripts/Core/Enemy/JackFlowerBossController.cs
@@ -17,6 +17,8 @@ namespace Game.Core.Enemy
     /// </summary>
     public sealed class JackFlowerBossVineSpawner : MonoBehaviour
     {
+        public static event System.Action BossDefeated;
+
         [Header("蔦の生成")]
         [SerializeField] private GameObject _vinePrefab;
         [SerializeField, Min(0.1f)] private float _spawnInterval = 4f;
@@ -49,6 +51,7 @@ namespace Game.Core.Enemy
         private Animator _bossAnimator;
         private Coroutine _spawnCoroutine;
         private bool _spawnLeftNext = true;
+        private bool _enemyEventsSubscribed;
 
         private void Awake()
         {
@@ -59,7 +62,14 @@ namespace Game.Core.Enemy
 
         private void OnEnable()
         {
+            TrySubscribeEnemyEvents();
             _spawnCoroutine = StartCoroutine(SpawnRoutine());
+        }
+
+        private void Start()
+        {
+            // EnemyControllerはEnemySpawnerから後付けされるため、Startでも取得を試みる。
+            TrySubscribeEnemyEvents();
         }
 
         private void OnDisable()
@@ -69,6 +79,61 @@ namespace Game.Core.Enemy
                 StopCoroutine(_spawnCoroutine);
                 _spawnCoroutine = null;
             }
+
+            UnsubscribeEnemyEvents();
+            ClearActiveVines();
+        }
+
+        private void OnDestroy()
+        {
+            UnsubscribeEnemyEvents();
+        }
+
+        private void TrySubscribeEnemyEvents()
+        {
+            if (_enemyEventsSubscribed)
+            {
+                return;
+            }
+
+            _enemyController ??= GetComponentInParent<EnemyController>();
+            if (_enemyController == null)
+            {
+                return;
+            }
+
+            _enemyController.OnDefeated += HandleBossDefeated;
+            _enemyEventsSubscribed = true;
+        }
+
+        private void UnsubscribeEnemyEvents()
+        {
+            if (!_enemyEventsSubscribed || _enemyController == null)
+            {
+                return;
+            }
+
+            _enemyController.OnDefeated -= HandleBossDefeated;
+            _enemyEventsSubscribed = false;
+        }
+
+        private void HandleBossDefeated()
+        {
+            ClearActiveVines();
+            BossDefeated?.Invoke();
+        }
+
+        private void ClearActiveVines()
+        {
+            foreach (JackFlowerVine vine in _activeVines)
+            {
+                if (vine != null)
+                {
+                    Destroy(vine.gameObject);
+                }
+            }
+
+            _activeVines.Clear();
         }
 
         private IEnumerator SpawnRoutine()

--- a/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs
+++ b/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs
@@ -55,7 +55,11 @@ namespace Game.Core.Enemy
         {
             while (enabled && !_bossDefeated)
             {
-                SpawnVine();
+                if (FindFirstObjectByType<JackFlowerBossVineSpawner>() != null)
+                {
+                    SpawnVine();
+                }
+
                 yield return new WaitForSeconds(_spawnInterval);
             }
         }

--- a/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs
+++ b/Assets/Scripts/Core/Enemy/StageCollectibleVineSpawner.cs
@@ -30,9 +30,12 @@ namespace Game.Core.Enemy
         private readonly List<StageCollectibleVine> _activeVines = new();
         private CollectibleSpawner _collectibleSpawner;
         private Coroutine _spawnCoroutine;
+        private bool _bossDefeated;
 
         private void OnEnable()
         {
+            _bossDefeated = false;
+            JackFlowerBossVineSpawner.BossDefeated += HandleBossDefeated;
             _spawnCoroutine = StartCoroutine(SpawnRoutine());
         }
 
@@ -43,15 +46,43 @@ namespace Game.Core.Enemy
                 StopCoroutine(_spawnCoroutine);
                 _spawnCoroutine = null;
             }
+
+            JackFlowerBossVineSpawner.BossDefeated -= HandleBossDefeated;
+            ClearActiveVines();
         }
 
         private IEnumerator SpawnRoutine()
         {
-            while (enabled)
+            while (enabled && !_bossDefeated)
             {
                 SpawnVine();
                 yield return new WaitForSeconds(_spawnInterval);
             }
+        }
+
+        private void HandleBossDefeated()
+        {
+            _bossDefeated = true;
+            if (_spawnCoroutine != null)
+            {
+                StopCoroutine(_spawnCoroutine);
+                _spawnCoroutine = null;
+            }
+
+            ClearActiveVines();
+        }
+
+        private void ClearActiveVines()
+        {
+            foreach (StageCollectibleVine vine in _activeVines)
+            {
+                if (vine != null)
+                {
+                    Destroy(vine.gameObject);
+                }
+            }
+
+            _activeVines.Clear();
         }
 
         private void SpawnVine()


### PR DESCRIPTION
## 概要
ボスのツル生成に関するロジックを調整し、同時に出現するツルの最大数を減らしました。

## 変更内容
- `Boss.prefab`: `_maxActiveVines`（同時出現数）を2から1に変更。
- `StageCollectibleVineSpawner.cs`: `JackFlowerBossVineSpawner` がシーンに存在する場合のみ `SpawnVine()` を実行するように条件を追加。
- `EnemyRising.cs`: 空行の追加（微修正）。

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [x] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [x] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [x] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [x] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データを書き換えているのは「所有システム」のみか
- [x] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [x] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #473
