### PR TITLE
feat: Ghost/Zombieのヒット・死亡リアクションを強化

### DIFF
--- a/Assets/Prefab/Enemy/GhostBody.prefab
+++ b/Assets/Prefab/Enemy/GhostBody.prefab
@@ -167,3 +167,6 @@ MonoBehaviour:
   _addHitAnimationTime: 1
   _dropDuration: 0.5
   _dropRot: {x: 0, y: 90, z: -180}
+  _postFlipDelay: 0.25
+  _useCartoonFeedback: 1
+  _flipOvershoot: {x: 0, y: 0, z: -25}

--- a/Assets/Prefab/Enemy/ZombiBody.prefab
+++ b/Assets/Prefab/Enemy/ZombiBody.prefab
@@ -141,6 +141,9 @@ MonoBehaviour:
   _addHitAnimationTime: 1
   _dropDuration: 0.3
   _dropRot: {x: -180, y: 0, z: 0}
+  _postFlipDelay: 0.25
+  _useCartoonFeedback: 1
+  _flipOvershoot: {x: -25, y: 0, z: 0}
 --- !u!136 &3699580084391280425
 CapsuleCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/Enemy/EnemyBodyController.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyBodyController.cs
@@ -1,8 +1,6 @@
-using Game.Core.Enemy;
-using UnityEngine;
-using Game.Core.Events;
-using Unity.Mathematics;
+using System;
 using System.Collections;
+using UnityEngine;
 
 namespace Game.Core.Enemy
 {
@@ -22,31 +20,51 @@ namespace Game.Core.Enemy
         [Header("Pose")]
         [SerializeField] float _dropDuration = 1.0f;
         [SerializeField] Vector3 _dropRot;
+        [SerializeField, Min(0f)] float _postFlipDelay = 0.25f;
         Coroutine _dropPoseCoroutine;
-        float _elapsedTime;
-        Quaternion _startRot;
 
-        private void Start()
-        {
-            var controller = GetComponentInParent<EnemyController>();
-            if (controller != null)
-            {
-                controller.OnDropStarted += OnDropStarted;
-            }
-        }
+        [Header("Cartoon Feedback")]
+        [SerializeField] bool _useCartoonFeedback;
+        [SerializeField] Transform _squashTarget;
+        [SerializeField, Min(0f)] float _hitSquashDuration = 0.06f;
+        [SerializeField, Min(0f)] float _hitStretchDuration = 0.07f;
+        [SerializeField, Min(0f)] float _hitRecoverDuration = 0.09f;
+        [SerializeField] Vector3 _hitSquashScale = new Vector3(1.12f, 0.82f, 1.12f);
+        [SerializeField] Vector3 _hitStretchScale = new Vector3(0.94f, 1.12f, 0.94f);
+        [SerializeField] Vector3 _hitRecoilRotation = new Vector3(-10f, 5f, 12f);
+        [SerializeField] Vector3 _hitReboundRotation = new Vector3(4f, -2f, -5f);
+        [SerializeField, Min(0f)] float _deathAnticipationDuration = 0.08f;
+        [SerializeField] Vector3 _deathSquashScale = new Vector3(1.18f, 0.72f, 1.18f);
+        [SerializeField] Vector3 _deathStretchScale = new Vector3(0.88f, 1.18f, 0.88f);
+        [SerializeField] Vector3 _flipOvershoot;
+        [SerializeField, Min(0f)] float _deathWobbleAngle = 6f;
+        [SerializeField, Min(0)] int _deathWobbleCycles = 2;
 
-        private void OnDestroy()
-        {
-            var controller = GetComponentInParent<EnemyController>();
-            if (controller != null)
-            {
-                controller.OnDropStarted -= OnDropStarted;
-            }
-        }
+        bool _enableCartoonFeedback;
+        bool _isPlayingDropPose;
+        Quaternion _baseBodyRotation;
+        Quaternion _hitRotationOffset = Quaternion.identity;
+        int _hitDirection = 1;
+        Vector3 _baseVisualScale;
+        Vector3 _visualScaleMultiplier = Vector3.one;
+        Coroutine _hitFeedbackCoroutine;
 
-        public void Initialize(string enemyID)
+        public void Initialize(string enemyID, bool allowCartoonFeedback)
         {
             _enemyID = enemyID;
+            _enableCartoonFeedback = _useCartoonFeedback && allowCartoonFeedback;
+            _baseBodyRotation = transform.localRotation;
+
+            if (_enableCartoonFeedback && _squashTarget == null)
+            {
+                _squashTarget = FindChildByName(transform, "root");
+            }
+
+            if (_squashTarget != null)
+            {
+                _baseVisualScale = _squashTarget.localScale;
+            }
+
             _receiver = GetComponent<EnemyHitReceiver>();
             if (_receiver != null)
             {
@@ -66,29 +84,229 @@ namespace Game.Core.Enemy
             _animator.SetFloat("HitTime", _hitAnimationTime);
         }
 
+        private void LateUpdate()
+        {
+            if (!_enableCartoonFeedback) return;
+
+            if (_squashTarget != null)
+            {
+                _squashTarget.localScale = Vector3.Scale(_baseVisualScale, _visualScaleMultiplier);
+            }
+
+            if (!_isPlayingDropPose)
+            {
+                transform.localRotation = _baseBodyRotation * _hitRotationOffset;
+            }
+        }
+
         void HandleHitDamage()
         {
             _hitAnimationTime += _addHitAnimationTime;
             _hitAnimationTime = Mathf.Min(_hitAnimationTime, _maxHitAnimationTime);
             if (_animator != null) _animator.SetTrigger("HitAnimeEvent");
-        }
 
-        void OnDropStarted()
-        {
-            _elapsedTime = 0.0f;
-            _startRot = transform.rotation;
-            if (_dropPoseCoroutine != null) StopCoroutine(_dropPoseCoroutine);
-            _dropPoseCoroutine = StartCoroutine(DropRoutine());
-        }
-
-        private IEnumerator DropRoutine()
-        {
-            while (_elapsedTime <= 1.0f)
+            if (_enableCartoonFeedback && !_isPlayingDropPose)
             {
-                _elapsedTime += Time.deltaTime / _dropDuration;
-                transform.rotation = Quaternion.Euler(Vector3.Lerp(_startRot.eulerAngles, _dropRot, _elapsedTime));
+                if (_hitFeedbackCoroutine != null) StopCoroutine(_hitFeedbackCoroutine);
+                _visualScaleMultiplier = Vector3.one;
+                _hitRotationOffset = Quaternion.identity;
+                _hitDirection *= -1;
+                _hitFeedbackCoroutine = StartCoroutine(HitFeedbackRoutine());
+            }
+        }
+
+        public void PlayDropPose(Action onCompleted)
+        {
+            if (_dropPoseCoroutine != null) StopCoroutine(_dropPoseCoroutine);
+            if (_hitFeedbackCoroutine != null)
+            {
+                StopCoroutine(_hitFeedbackCoroutine);
+                _hitFeedbackCoroutine = null;
+            }
+
+            _isPlayingDropPose = true;
+            _visualScaleMultiplier = Vector3.one;
+            _hitRotationOffset = Quaternion.identity;
+            transform.localRotation = _baseBodyRotation;
+            _dropPoseCoroutine = StartCoroutine(DropRoutine(onCompleted));
+        }
+
+        private IEnumerator HitFeedbackRoutine()
+        {
+            Quaternion recoilRotation = CreateDirectionalRotation(_hitRecoilRotation, _hitDirection);
+            Quaternion reboundRotation = CreateDirectionalRotation(_hitReboundRotation, _hitDirection);
+
+            yield return AnimateHitPose(Vector3.one, _hitSquashScale, Quaternion.identity, recoilRotation, _hitSquashDuration);
+            yield return AnimateHitPose(_hitSquashScale, _hitStretchScale, recoilRotation, reboundRotation, _hitStretchDuration);
+            yield return AnimateHitPose(_hitStretchScale, Vector3.one, reboundRotation, Quaternion.identity, _hitRecoverDuration);
+
+            _visualScaleMultiplier = Vector3.one;
+            _hitRotationOffset = Quaternion.identity;
+            _hitFeedbackCoroutine = null;
+        }
+
+        private IEnumerator DropRoutine(Action onCompleted)
+        {
+            Quaternion startRotation = transform.localRotation;
+            Quaternion targetRotation = Quaternion.Euler(_dropRot);
+
+            if (!_enableCartoonFeedback)
+            {
+                float rotationElapsedTime = 0f;
+                while (rotationElapsedTime < _dropDuration)
+                {
+                    rotationElapsedTime += Time.deltaTime;
+                    float progress = _dropDuration > 0f ? Mathf.Clamp01(rotationElapsedTime / _dropDuration) : 1f;
+                    transform.localRotation = Quaternion.Slerp(startRotation, targetRotation, Mathf.SmoothStep(0f, 1f, progress));
+                    yield return null;
+                }
+
+                transform.localRotation = targetRotation;
+                if (_postFlipDelay > 0f) yield return new WaitForSeconds(_postFlipDelay);
+
+                _dropPoseCoroutine = null;
+                onCompleted?.Invoke();
+                yield break;
+            }
+
+            if (_enableCartoonFeedback)
+            {
+                yield return AnimateVisualScale(Vector3.one, _deathSquashScale, _deathAnticipationDuration);
+            }
+
+            float elapsedTime = 0f;
+            Quaternion overshootRotation = targetRotation * Quaternion.Euler(_flipOvershoot);
+            float overshootDuration = _dropDuration * 0.72f;
+            float settleDuration = Mathf.Max(0f, _dropDuration - overshootDuration);
+
+            while (elapsedTime < overshootDuration)
+            {
+                elapsedTime += Time.deltaTime;
+                float progress = overshootDuration > 0f ? Mathf.Clamp01(elapsedTime / overshootDuration) : 1f;
+                float easedProgress = Mathf.SmoothStep(0f, 1f, progress);
+                if (_enableCartoonFeedback && easedProgress > 0.8f)
+                {
+                    transform.localRotation = Quaternion.Slerp(targetRotation, overshootRotation, (easedProgress - 0.8f) / 0.2f);
+                }
+                else
+                {
+                    transform.localRotation = Quaternion.Slerp(startRotation, targetRotation, Mathf.Min(easedProgress / 0.8f, 1f));
+                }
+
+                if (_enableCartoonFeedback)
+                {
+                    _visualScaleMultiplier = Vector3.LerpUnclamped(_deathSquashScale, _deathStretchScale, easedProgress);
+                }
                 yield return null;
             }
+
+            elapsedTime = 0f;
+            while (_enableCartoonFeedback && elapsedTime < settleDuration)
+            {
+                elapsedTime += Time.deltaTime;
+                float progress = settleDuration > 0f ? Mathf.Clamp01(elapsedTime / settleDuration) : 1f;
+                float easedProgress = Mathf.SmoothStep(0f, 1f, progress);
+                transform.localRotation = Quaternion.Slerp(overshootRotation, targetRotation, easedProgress);
+                _visualScaleMultiplier = Vector3.LerpUnclamped(_deathStretchScale, Vector3.one, easedProgress);
+                yield return null;
+            }
+
+            transform.localRotation = targetRotation;
+            _visualScaleMultiplier = Vector3.one;
+
+            if (_postFlipDelay > 0f)
+            {
+                if (_enableCartoonFeedback && _deathWobbleAngle > 0f && _deathWobbleCycles > 0)
+                {
+                    elapsedTime = 0f;
+                    while (elapsedTime < _postFlipDelay)
+                    {
+                        elapsedTime += Time.deltaTime;
+                        float progress = Mathf.Clamp01(elapsedTime / _postFlipDelay);
+                        float damping = 1f - progress;
+                        float wobble = Mathf.Sin(progress * Mathf.PI * 2f * _deathWobbleCycles) * _deathWobbleAngle * damping;
+                        transform.localRotation = targetRotation * Quaternion.Euler(0f, 0f, wobble);
+                        yield return null;
+                    }
+                    transform.localRotation = targetRotation;
+                }
+                else
+                {
+                    yield return new WaitForSeconds(_postFlipDelay);
+                }
+            }
+
+            _dropPoseCoroutine = null;
+            onCompleted?.Invoke();
+        }
+
+        private IEnumerator AnimateVisualScale(Vector3 from, Vector3 to, float duration)
+        {
+            if (_squashTarget == null || duration <= 0f)
+            {
+                _visualScaleMultiplier = to;
+                yield break;
+            }
+
+            float elapsedTime = 0f;
+            while (elapsedTime < duration)
+            {
+                elapsedTime += Time.deltaTime;
+                float progress = Mathf.Clamp01(elapsedTime / duration);
+                _visualScaleMultiplier = Vector3.LerpUnclamped(from, to, Mathf.SmoothStep(0f, 1f, progress));
+                yield return null;
+            }
+
+            _visualScaleMultiplier = to;
+        }
+
+        private IEnumerator AnimateHitPose(
+            Vector3 fromScale,
+            Vector3 toScale,
+            Quaternion fromRotation,
+            Quaternion toRotation,
+            float duration)
+        {
+            if (duration <= 0f)
+            {
+                _visualScaleMultiplier = toScale;
+                _hitRotationOffset = toRotation;
+                yield break;
+            }
+
+            float elapsedTime = 0f;
+            while (elapsedTime < duration)
+            {
+                elapsedTime += Time.deltaTime;
+                float progress = Mathf.SmoothStep(0f, 1f, Mathf.Clamp01(elapsedTime / duration));
+                _visualScaleMultiplier = Vector3.LerpUnclamped(fromScale, toScale, progress);
+                _hitRotationOffset = Quaternion.SlerpUnclamped(fromRotation, toRotation, progress);
+                yield return null;
+            }
+
+            _visualScaleMultiplier = toScale;
+            _hitRotationOffset = toRotation;
+        }
+
+        private static Quaternion CreateDirectionalRotation(Vector3 eulerAngles, int direction)
+        {
+            return Quaternion.Euler(eulerAngles.x, eulerAngles.y * direction, eulerAngles.z * direction);
+        }
+
+        private static Transform FindChildByName(Transform parent, string childName)
+        {
+            foreach (Transform child in parent)
+            {
+                if (string.Equals(child.name, childName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return child;
+                }
+
+                Transform found = FindChildByName(child, childName);
+                if (found != null) return found;
+            }
+
+            return null;
         }
     }
 }

--- a/Assets/Scripts/Core/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyController.cs
@@ -61,6 +61,7 @@ namespace Game.Core.Enemy
         private EnemyAttack _enemyAttack;
         private EnemyHoldCounter _holdCounter;
         private EnemyDebuffManager _debuffManager;
+        private EnemyBodyController _bodyController;
         private Coroutine _downTimerCoroutine;
 
         public event System.Action<float, float> OnHealthChanged;
@@ -80,9 +81,10 @@ namespace Game.Core.Enemy
         /// Awake後の動的生成（スポーン）でも呼び出せる。
         /// </summary>
         /// <param name="def">適用するEnemyDefinition</param>
-        public string Initialize(EnemyDefinition definition, SpawnSummary spawnSummary)
+        public string Initialize(EnemyDefinition definition, SpawnSummary spawnSummary, EnemyBodyController bodyController)
         {
             _definition = definition;
+            _bodyController = bodyController;
             InstanceEnemyId = $"{definition.EnemyId}_{GetInstanceID()}";
 
             // 状態管理初期化
@@ -251,7 +253,11 @@ namespace Game.Core.Enemy
             _debuffManager.AddHit();
             if (_stateManager.CurrentState == EnemyState.OverHit) _holdCounter.AddHit();
             _health.ApplyBodyDamage(bodyDamage);
-            _rising.DamageDrop(transform);
+
+            if (_stateManager.CurrentState == EnemyState.Normal || _stateManager.CurrentState == EnemyState.Down)
+            {
+                _rising.DamageDrop(transform);
+            }
         }
 
         public void OnAddDebuff(EnemyDebuffConfig _config)
@@ -328,8 +334,19 @@ namespace Game.Core.Enemy
         /// </summary>
         private void HandleHoldEnd()
         {
-            // ステートを遷移し落下
             _stateManager.TransitionTo(EnemyState.Drop);
+
+            if (!_definition.IsBoss && _bodyController != null)
+            {
+                _bodyController.PlayDropPose(BeginDefeatDrop);
+                return;
+            }
+
+            BeginDefeatDrop();
+        }
+
+        private void BeginDefeatDrop()
+        {
             _rising.ResumeMove();
             _rising.DropStart(transform);
             OnDropStarted?.Invoke();

--- a/Assets/Scripts/Core/Enemy/EnemyRising.cs
+++ b/Assets/Scripts/Core/Enemy/EnemyRising.cs
@@ -234,7 +234,7 @@ namespace Game.Core.Enemy
         /// <param name="_enemyTransform">トランスフォーム</param>
         public void DamageDrop(Transform _enemyTransform)
         {
-            if (_enemyMoveState == EnemyMoveState.BreakDrop) return;
+            if (_enemyMoveState == EnemyMoveState.BreakDrop || _enemyMoveState == EnemyMoveState.Drop) return;
 
             if (_riseCoroutine != null) StopCoroutine(_riseCoroutine);
             if (_damageDropCoroutine != null) StopCoroutine(_damageDropCoroutine);
@@ -274,6 +274,7 @@ namespace Game.Core.Enemy
 
             //-イージング処理完了後開始地点に位置を補正
             enemyTransform.position = _startPosition;
+            _dropCoroutine = null;
             OnEnemyDroped?.Invoke();
         }
 
@@ -437,6 +438,11 @@ namespace Game.Core.Enemy
             if (_riseCoroutine != null) StopCoroutine(_riseCoroutine);
             if (_dropCoroutine != null) StopCoroutine(_dropCoroutine);
             if (_breakDropCoroutine != null) StopCoroutine(_breakDropCoroutine);
+            if (_damageDropCoroutine != null)
+            {
+                StopCoroutine(_damageDropCoroutine);
+                _damageDropCoroutine = null;
+            }
             _isStopping = true;
         }
 
@@ -449,7 +455,10 @@ namespace Game.Core.Enemy
                     _riseCoroutine = StartCoroutine(RiseRoutine(transform));
                     break;
                 case EnemyMoveState.Drop:
-                    _dropCoroutine = StartCoroutine(DropRoutine(transform));
+                    if (_dropCoroutine == null)
+                    {
+                        _dropCoroutine = StartCoroutine(DropRoutine(transform));
+                    }
                     break;
                 case EnemyMoveState.BreakDrop:
                     _breakDropCoroutine = StartCoroutine(BreakDropRoutine(transform));

--- a/Assets/Scripts/Core/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Core/Enemy/EnemySpawner.cs
@@ -190,8 +190,8 @@ namespace Game.Core.Enemy
             }
 
             EnemyController.SpawnSummary spawnSummary = new EnemyController.SpawnSummary(targetPos, _undergroundOffset, _currentHpRate, _currentBarrierRate);
-            string enemyId = controller.Initialize(definition, spawnSummary);
-            bodyController.Initialize(enemyId);
+            string enemyId = controller.Initialize(definition, spawnSummary, bodyController);
+            bodyController.Initialize(enemyId, !definition.IsBoss);
 
             if (definition.HasBarrier && barrier != null)
             {


### PR DESCRIPTION
## 概要
Ghost/Zombieのヒット時・死亡時リアクションをカートゥーン調に強化しました。

## 変更内容
- ヒット時にSquash & Stretch、のけぞり、左右交互の横振れを追加
- 連続ヒット時は進行中のリアクションを再始動
- 死亡時に予備動作、反転オーバーシュート、減衰揺れを追加
- 反転完了後に短く静止してから落下を開始
- Bossにはカートゥーン演出を適用しない
- 最新masterを取り込み、PR #514の攻撃モーション開始・終了処理と統合

## 確認項目 (セルフチェック)
### 実装・品質
- [x] 命名規則を確認
- [x] 新規ファイルなし、メタファイル変更なし
- [x] デバッグログ・不要なusingの追加なし

### 設計・アーキテクチャ
- [x] 既存のヒット・ダメージ・コンボ処理を維持
- [x] 攻撃モーションの中断・再開処理を維持
- [x] 死亡落下とヒットリアクションの責務を分離
- [x] 新規依存関係なし

## 検証
- [x] 対象6ファイルのgit diff --check
- [x] Unity 6000.3.7f1 batchmode初回インポート・スクリプトコンパイル（終了コード0）
- [x] dotnet build Assembly-CSharp.csproj --nologo（0エラー）
- [x] AnimatorのAttack / AttackAnimeEvent / AttackAnimeEndEvent / HitTime参照を照合
- [ ] Unity Play Modeでの目視確認

## 関連Issue
Closes #517

## その他 (懸念点・共有事項)
- 回転量・揺れ量の最終的な見た目は、Unity Play Modeで目視確認してください。