### PR TITLE
[#519] 敵の状態異常エフェクトが出現しない問題を修正

### DIFF
--- a/Assets/Prefab/Enemy/EnemySpawnTest.prefab
+++ b/Assets/Prefab/Enemy/EnemySpawnTest.prefab
@@ -44,33 +44,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 48ace6592fc2c9a489aed5ee94288a32, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemySpawner
-  _spawnAction:
-    m_Name: Spawn
-    m_Type: 0
-    m_ExpectedControlType: 
-    m_Id: 6c4795c7-8096-4d6a-9f10-cf048b74810e
-    m_Processors: 
-    m_Interactions: 
-    m_SingletonActionBindings:
-    - m_Name: 
-      m_Id: 0ac29537-95e0-45bf-bc90-9c68e937e545
-      m_Path: <Keyboard>/f10
-      m_Interactions: 
-      m_Processors: 
-      m_Groups: 
-      m_Action: Spawn
-      m_Flags: 0
-    m_Flags: 0
-  _enemyPrefab: {fileID: 8990543758482931198, guid: 1929e3aeac607824092eabd95578b649, type: 3}
-  _definition: {fileID: 11400000, guid: 4cb55c9a8a363064c9bf094f77b06186, type: 2}
-  _rangeSize: {x: 10, y: 2}
+  _rangeSize: {x: 36.3, y: 2}
+  _statusAilmentVFXEntries:
+  - DebuffType: Poison
+    LoopVFXPrefab: {fileID: 8035996757950515496, guid: 170793df188586a41bad20c0bff1a0b2, type: 3}
+    DeathVFXPrefab: {fileID: 764230422517785610, guid: a3903a9f1a5a421439e626b15ab82bf2, type: 3}
+    OverlayMaterial: {fileID: 2100000, guid: 93aad8f6debfb4b49a80725137d766e4, type: 2}
+    ChildScale: {x: 3.63, y: 3.63, z: 3.63}
+  - DebuffType: Ice
+    LoopVFXPrefab: {fileID: 8521017165506079719, guid: ff5b1301f5cdbc046b8000c9a85be2f2, type: 3}
+    DeathVFXPrefab: {fileID: 3140498029041030553, guid: 6c17ff86033df8e41b754e11780e86d8, type: 3}
+    OverlayMaterial: {fileID: 2100000, guid: 32a997adbcf97d346882114aa4a4dffe, type: 2}
+    ChildScale: {x: 3.63, y: 3.63, z: 3.63}
+  _statusAilmentVFXRoot: {fileID: 0}
+  _statusAilmentVFXOffset: {x: 0, y: -0.83, z: -2.01}
   _spawnBasePoint: {fileID: 8125261586118470773}
-  _undergroundOffset: 0
-  _minDistanceFromOtherEnemies: 3
-  _maxSpawnPositionAttempts: 20
-  _enableAutoSpawn: 1
-  _initialSpawnDelay: 2
-  _spawnInterval: 5
-  _enemiesPerSpawn: 1
-  _maxAliveEnemies: 3
-  _enemySpawnerDefinition: {fileID: 11400000, guid: f14a04607d1020d4c9a6e8adde6d5a6e, type: 2}
+  _undergroundOffset: 10

--- a/Assets/Scripts/Core/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Core/Enemy/EnemySpawner.cs
@@ -41,7 +41,7 @@ namespace Game.Core.Enemy
         [SerializeField] private Transform _statusAilmentVFXRoot;
 
         [Tooltip("状態異常VFXのローカルオフセット（敵の上に表示したい場合は Y を正に）")]
-        [SerializeField] private Vector3 _statusAilmentVFXOffset = new Vector3(0.24f, 1.31f, 0f);
+        [SerializeField] private Vector3 _statusAilmentVFXOffset = new Vector3(0f, -0.83f, -2.01f);
 
         [Header("出現位置の設定")]
         [Tooltip("最終目標地点")]

--- a/Assets/tex/skull.png
+++ b/Assets/tex/skull.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f305bb88e468ec5d87c56692729d023be7dab9c62f17bd6b3dcdd5770f6a30b8
+size 205157

--- a/Assets/tex/skull.png.meta
+++ b/Assets/tex/skull.png.meta
@@ -1,0 +1,117 @@
+fileFormatVersion: 2
+guid: 0746d9590a92e5046b7c148542521629
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData:
+    physicsShape: []
+    bones: []
+    spriteID:
+    internalID: 0
+    vertices: []
+    indices:
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName:
+  pSDRemoveMatte: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 概要
敵生成時に状態異常VFXの設定が空のまま渡され、毒・氷エフェクトが出現しない問題を修正します。

## 変更内容
- `EnemySpawnTest`へPoison／IceのループVFX、死亡VFX、オーバーレイMaterialを登録
- 状態異常VFXの表示位置を敵モデルに合わせて`(0, -0.83, -2.01)`へ調整
- Poison VFXが参照する`skull.png`とUnityメタファイルを追加
- 旧`EnemySpawner`のシリアライズ項目を現在の構造へ更新

## 確認結果
- `dotnet build Game.Runtime.csproj --no-restore`：成功（警告0、エラー0）
- `dotnet format Game.Runtime.csproj --verify-no-changes --include Assets/Scripts/Core/Enemy/EnemySpawner.cs --no-restore`：成功
- `git diff --cached --check`：成功

## 確認項目 (セルフチェック)

### 💻 実装・品質
- [x] **命名規則**: 既存の命名規則に準拠
- [ ] **整形**: 変更ファイルは成功。リポジトリ全体では今回の対象外である既存3ファイルの行末・空白により失敗
- [x] **メタファイル**: 新規テクスチャの`.meta`を追加
- [x] **不要な変更**: 未参照Prefab、Stage再シリアライズ、環境生成物を除外

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: `EnemySpawner`から既存の`EnemyStatusAilmentVFX`へ設定を注入
- [x] **Viewの責務**: データ更新処理の変更なし
- [x] **依存関係**: 新しいコード依存なし

## 関連Issue
Closes #519

## その他 (懸念点・共有事項)
UnityのGameビュー上での最終表示確認は未実施です。