### PR TITLE
[#540] ロードシーンとゲーム開始演出を追加

### DIFF
--- a/Assets/Scenes/Loading.unity
+++ b/Assets/Scenes/Loading.unity
@@ -1,0 +1,174 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  m_Layer: 0
+  m_Name: LoadingFlowRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1f4720c9d6e4b8cb1537e2f904ad685, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Infrastructure.Loading.LoadingFlowController
+  _bootSceneName: Boot
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 100001}

--- a/Assets/Scenes/Loading.unity.meta
+++ b/Assets/Scenes/Loading.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c3a9f5d6e1724b4e9238d7a1f6c0b5e4
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -2981,7 +2981,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Game.Presentation.UI.Title.TitleMenuController
   _startButton: {fileID: 1090685987}
-  _bootSceneName: Boot
+  _loadingSceneName: Loading
 --- !u!1 &1985533822
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/Management/GameProgressionManager.cs
+++ b/Assets/Scripts/Core/Management/GameProgressionManager.cs
@@ -61,6 +61,10 @@ namespace Game.Core.Management
         private int _currentWaveIndex = 0;
         private bool _isCameraWorkFinished = false;
         private List<WaveDataSO> _waveSequence = new();
+        private bool _isFirstWavePrepared;
+        private bool _hasGameStarted;
+        private bool _preparationFailed;
+        private bool _isPreparingFirstWave;
 
 
         // カメラの固定画角を保持しておく変数
@@ -121,7 +125,11 @@ namespace Game.Core.Management
 
         private void Start()
         {
-            StartCoroutine(WaitAndStartFirstWaveRoutine());
+            Scene loadingScene = SceneManager.GetSceneByName("Loading");
+            if (!loadingScene.IsValid() || !loadingScene.isLoaded)
+            {
+                StartCoroutine(PrepareAndBeginForStandaloneRoutine());
+            }
         }
 
         private void OnEnable()
@@ -468,8 +476,21 @@ namespace Game.Core.Management
         /// <summary>
         /// 加算ロード完了後、StageDataSOからWave順を生成して開始します。
         /// </summary>
-        private IEnumerator WaitAndStartFirstWaveRoutine()
+        public IEnumerator PrepareFirstWaveRoutine()
         {
+            if (_isFirstWavePrepared || _preparationFailed)
+            {
+                yield break;
+            }
+
+            if (_isPreparingFirstWave)
+            {
+                yield return new WaitUntil(() => _isFirstWavePrepared || _preparationFailed);
+                yield break;
+            }
+
+            _isPreparingFirstWave = true;
+
             // 初期化
             _currentWaveIndex = 0;
             _currentState = GameProgressionState.Setup;
@@ -494,6 +515,8 @@ namespace Game.Core.Management
             if (_waveRunner == null)
             {
                 Debug.LogError("[Progression] WaveRunnerがGameProgressionManagerと同じGameObjectにありません。");
+                _preparationFailed = true;
+                _isPreparingFirstWave = false;
                 yield break;
             }
 
@@ -501,6 +524,8 @@ namespace Game.Core.Management
             if (stageContext.ManualTestMode)
             {
                 Debug.Log("[Progression] 手動テストモードのため、自動Wave進行をスキップします");
+                _isFirstWavePrepared = true;
+                _isPreparingFirstWave = false;
                 yield break;
             }
 
@@ -512,6 +537,8 @@ namespace Game.Core.Management
             if (!StageWaveSequenceBuilder.TryBuild(stageContext.StageData, seed, out List<WaveDataSO> waveSequence, out string errorMessage))
             {
                 Debug.LogError($"[Progression] Wave順の生成に失敗しました。\n{errorMessage}", stageContext);
+                _preparationFailed = true;
+                _isPreparingFirstWave = false;
                 yield break;
             }
 
@@ -520,8 +547,32 @@ namespace Game.Core.Management
 
             Debug.Log($"[Progression] Stage開始：{stageContext.StageData.StageName} / Seed：{seed} / Wave数：{_waveSequence.Count}");
 
-            // 最初のWaveを開始
+            _isFirstWavePrepared = true;
+            _isPreparingFirstWave = false;
+        }
+
+        public bool IsFirstWavePrepared => _isFirstWavePrepared;
+        public bool PreparationFailed => _preparationFailed;
+
+        public void BeginPreparedGame()
+        {
+            if (!_isFirstWavePrepared ||
+                _preparationFailed ||
+                _hasGameStarted ||
+                _waveSequence == null ||
+                _waveSequence.Count == 0)
+            {
+                return;
+            }
+
+            _hasGameStarted = true;
             StartBattleWave(_currentWaveIndex);
+        }
+
+        private IEnumerator PrepareAndBeginForStandaloneRoutine()
+        {
+            yield return PrepareFirstWaveRoutine();
+            BeginPreparedGame();
         }
 
         /// <summary>

--- a/Assets/Scripts/Core/Management/GameResetManager.cs
+++ b/Assets/Scripts/Core/Management/GameResetManager.cs
@@ -2,7 +2,7 @@
 // File         : GameResetManager.cs
 // Author       : Iwai Shogo
 //
-// Description  : 加算シーン一式をクリーンアップしてBootから再始動させるマネージャー。
+// Description  : 加算シーン一式をクリーンアップしてLoadingから再始動させるマネージャー。
 // Created      : 2026-07-02
 // ================================================================================
 
@@ -12,19 +12,18 @@ using UnityEngine.SceneManagement;
 namespace Game.Core.Management
 {
     /// <summary>
-    /// 加算シーン一式をクリーンアップしてBootから再始動させるマネージャー
+    /// 加算シーン一式をクリーンアップしてLoadingから再始動させるマネージャー
     /// </summary>
     public class GameResetManager
     {
         public static void TriggerFullReset()
         {
-            Debug.Log("[GameResetManager] 全シーンをクリーンアップし、ゲームをBootシーンから完全初期化するぜようおおおおお！");
+            Debug.Log("[GameResetManager] 全シーンをクリーンアップし、Loadingシーンから完全初期化します。");
 
             // タイムスケールを通常に戻す
             Time.timeScale = 1f;
 
-            // "Boot" シーンを単一ロード
-            SceneManager.LoadScene("Boot", LoadSceneMode.Single);
+            SceneManager.LoadScene("Loading", LoadSceneMode.Single);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Collectibles/Management/CollectiblePool.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Management/CollectiblePool.cs
@@ -31,6 +31,8 @@ namespace Game.Gameplay.Collectibles
 
         private List<CollectibleObject> _activeInField = new List<CollectibleObject>();
 
+        public bool IsPrewarmed { get; private set; }
+
         private void Awake()
         {
             if (Instance != null && Instance != this)
@@ -55,6 +57,8 @@ namespace Game.Gameplay.Collectibles
             {
                 CreateNewObject();
             }
+
+            IsPrewarmed = true;
         }
 
         private CollectibleObject CreateNewObject()

--- a/Assets/Scripts/Gameplay/Enemy/Boss/BossBattleController.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/BossBattleController.cs
@@ -820,7 +820,9 @@ namespace Game.Gameplay.Enemy.Boss
 
             if (failureBarrierDamage > 0f)
             {
-                EventBus.Publish(new RuleBarrierAttackEvent(failureBarrierDamage));
+                EventBus.Publish(new RuleBarrierAttackEvent(
+                    failureBarrierDamage,
+                    _mouthHitReceiver.transform.position));
             }
 
             if (_currentPhaseData == null)

--- a/Assets/Scripts/Gameplay/Enemy/Boss/BossThornBarrierAttacker.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/BossThornBarrierAttacker.cs
@@ -239,7 +239,7 @@ namespace Game.Gameplay.Enemy.Boss
             // イベント発効前に無効にしておく
             _hasDamagedBarrier = true;
 
-            EventBus.Publish(new RuleBarrierAttackEvent(_barrierDamage));
+            EventBus.Publish(new RuleBarrierAttackEvent(_barrierDamage, hitPosition));
 
             BarrierDamaged?.Invoke(_thorn, _barrierDamage, hitPosition);
 

--- a/Assets/Scripts/Infrastructure/Bootstrap/PrototypeSceneFlowController.cs
+++ b/Assets/Scripts/Infrastructure/Bootstrap/PrototypeSceneFlowController.cs
@@ -10,6 +10,7 @@
 // - 5/6: Bootから設計通りのAdditiveシーンを読み込む統合用Bootstrapを追加
 // ------------------------------------------------------------
 using System.Collections;
+using Game.Core.Management;
 using Game.Gameplay.Cameras;
 using Game.Gameplay.Collectibles;
 using Game.Gameplay.Player;
@@ -51,16 +52,24 @@ namespace Game.Infrastructure.Bootstrap
         [SerializeField] private bool _disablePlayerHoldMode = true;
 
         private bool _isBootstrapped;
+        private PlayerFacade _preparedPlayer;
+
+        public bool IsPrepared { get; private set; }
+        public bool PreparationFailed { get; private set; }
 
         private void Start()
         {
-            StartCoroutine(BootstrapRoutine());
+            Scene loadingScene = SceneManager.GetSceneByName("Loading");
+            if (!loadingScene.IsValid() || !loadingScene.isLoaded)
+            {
+                StartCoroutine(PrepareAndStartStandaloneRoutine());
+            }
         }
 
         /// <summary>
         /// シーン読み込み、参照接続、初期スポーンを順番に実行する。
         /// </summary>
-        private IEnumerator BootstrapRoutine()
+        public IEnumerator PrepareGameRoutine()
         {
             if (_isBootstrapped)
             {
@@ -74,6 +83,15 @@ namespace Game.Infrastructure.Bootstrap
             yield return LoadSceneIfNeeded(_uiScene);
             yield return LoadSceneIfNeeded(_debugScene);
 
+            if (!IsSceneLoaded(_gameplayShellScene) ||
+                !IsSceneLoaded(_stageScene) ||
+                !IsSceneLoaded(_uiScene) ||
+                !IsSceneLoaded(_debugScene))
+            {
+                PreparationFailed = true;
+                yield break;
+            }
+
             Scene gameplayScene = SceneManager.GetSceneByName(_gameplayShellScene);
             if (gameplayScene.IsValid())
             {
@@ -82,10 +100,36 @@ namespace Game.Infrastructure.Bootstrap
 
             yield return null;
 
-            PlayerFacade player = SpawnPlayer();
-            DisablePlayerHoldMode(player);
+            _preparedPlayer = SpawnPlayer();
+            if (_preparedPlayer == null)
+            {
+                PreparationFailed = true;
+                yield break;
+            }
+
+            SetPlayerMovement(_preparedPlayer, false);
+            DisablePlayerHoldMode(_preparedPlayer);
             ApplyCameraConfiguration();
             SpawnCollectibles();
+
+            yield return WaitForRuntimeInitialization();
+
+            GameProgressionManager progression = Object.FindFirstObjectByType<GameProgressionManager>();
+            if (progression == null)
+            {
+                Debug.LogError("[PrototypeSceneFlowController] GameProgressionManagerが見つかりません。");
+                PreparationFailed = true;
+                yield break;
+            }
+
+            yield return progression.PrepareFirstWaveRoutine();
+            if (progression.PreparationFailed || !progression.IsFirstWavePrepared)
+            {
+                PreparationFailed = true;
+                yield break;
+            }
+
+            IsPrepared = true;
         }
 
         /// <summary>
@@ -117,6 +161,56 @@ namespace Game.Infrastructure.Bootstrap
             {
                 yield return null;
             }
+        }
+
+        private static bool IsSceneLoaded(string sceneName)
+        {
+            Scene scene = SceneManager.GetSceneByName(sceneName);
+            return scene.IsValid() && scene.isLoaded;
+        }
+
+        private static IEnumerator WaitForRuntimeInitialization()
+        {
+            while (!Game.Gameplay.Stage.FieldContext.IsReady)
+            {
+                yield return null;
+            }
+
+            CollectiblePool pool = Object.FindFirstObjectByType<CollectiblePool>();
+            while (pool != null && !pool.IsPrewarmed)
+            {
+                yield return null;
+            }
+        }
+
+        public void StartPreparedGame()
+        {
+            if (!IsPrepared || PreparationFailed)
+            {
+                return;
+            }
+
+            SetPlayerMovement(_preparedPlayer, true);
+
+            GameProgressionManager progression = Object.FindFirstObjectByType<GameProgressionManager>();
+            progression?.BeginPreparedGame();
+        }
+
+        private static void SetPlayerMovement(PlayerFacade player, bool canMove)
+        {
+            if (player == null)
+            {
+                return;
+            }
+
+            PlayerController controller = player.GetComponentInChildren<PlayerController>(true);
+            controller?.SetCanMove(canMove);
+        }
+
+        private IEnumerator PrepareAndStartStandaloneRoutine()
+        {
+            yield return PrepareGameRoutine();
+            StartPreparedGame();
         }
 
         /// <summary>

--- a/Assets/Scripts/Infrastructure/Loading.meta
+++ b/Assets/Scripts/Infrastructure/Loading.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4b6802f7a934c5e8f1a6b3d209ec745
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Infrastructure/Loading/LoadingFlowController.cs
+++ b/Assets/Scripts/Infrastructure/Loading/LoadingFlowController.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using Game.Infrastructure.Bootstrap;
+using Game.Presentation.UI.Loading;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Game.Infrastructure.Loading
+{
+    public sealed class LoadingFlowController : MonoBehaviour
+    {
+        private const float MinimumLoadingDuration = 3f;
+
+        [SerializeField] private string _bootSceneName = "Boot";
+
+        private IEnumerator Start()
+        {
+            Time.timeScale = 1f;
+
+            LoadingView view = gameObject.AddComponent<LoadingView>();
+            view.Initialize();
+            float loadingStartedAt = Time.realtimeSinceStartup;
+
+            AsyncOperation bootLoad = SceneManager.LoadSceneAsync(_bootSceneName, LoadSceneMode.Additive);
+            if (bootLoad == null)
+            {
+                Debug.LogError($"[LoadingFlowController] {_bootSceneName}シーンのロード開始に失敗しました。");
+                yield break;
+            }
+
+            yield return bootLoad;
+
+            PrototypeSceneFlowController boot = Object.FindFirstObjectByType<PrototypeSceneFlowController>();
+            if (boot == null)
+            {
+                Debug.LogError("[LoadingFlowController] PrototypeSceneFlowControllerが見つかりません。");
+                yield break;
+            }
+
+            yield return boot.PrepareGameRoutine();
+            if (boot.PreparationFailed || !boot.IsPrepared)
+            {
+                Debug.LogError("[LoadingFlowController] ゲームの初期化に失敗しました。");
+                yield break;
+            }
+
+            yield return null;
+            Shader.WarmupAllShaders();
+            yield return null;
+
+            float remainingDuration = MinimumLoadingDuration - (Time.realtimeSinceStartup - loadingStartedAt);
+            if (remainingDuration > 0f)
+            {
+                yield return new WaitForSecondsRealtime(remainingDuration);
+            }
+
+            yield return view.PlayGameStartRoutine();
+
+            boot.StartPreparedGame();
+
+            AsyncOperation bootUnload = SceneManager.UnloadSceneAsync(_bootSceneName);
+            if (bootUnload != null)
+            {
+                yield return bootUnload;
+            }
+
+            Scene loadingScene = gameObject.scene;
+            Scene gameplayScene = SceneManager.GetSceneByName("GameplayShell");
+            if (gameplayScene.IsValid() && gameplayScene.isLoaded)
+            {
+                SceneManager.SetActiveScene(gameplayScene);
+            }
+
+            SceneManager.UnloadSceneAsync(loadingScene);
+        }
+    }
+}

--- a/Assets/Scripts/Infrastructure/Loading/LoadingFlowController.cs.meta
+++ b/Assets/Scripts/Infrastructure/Loading/LoadingFlowController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1f4720c9d6e4b8cb1537e2f904ad685

--- a/Assets/Scripts/Presentation/UI/Loading.meta
+++ b/Assets/Scripts/Presentation/UI/Loading.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5c7913a8b204d6f9a2b7c4e310fd856
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Presentation/UI/Loading/LoadingView.cs
+++ b/Assets/Scripts/Presentation/UI/Loading/LoadingView.cs
@@ -1,0 +1,357 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.Presentation.UI.Loading
+{
+    public sealed class LoadingView : MonoBehaviour
+    {
+        private const string TextureRoot = "Textures/Title/UI_Title_Logo/";
+
+        private readonly List<DecorationState> _decorations = new();
+        private Camera _loadingCamera;
+        private CanvasGroup _loadingGroup;
+        private Image _blackOverlay;
+        private RectTransform _logo;
+        private CanvasGroup _gameStartGroup;
+        private RectTransform[] _gameCharacters;
+        private float _logoAngle;
+        private bool _animateLoading = true;
+
+        private sealed class DecorationState
+        {
+            public RectTransform Transform;
+            public Vector2 BasePosition;
+            public Vector3 BaseScale;
+            public float Phase;
+            public float FloatHeight;
+            public float FloatSpeed;
+        }
+
+        public void Initialize()
+        {
+            CreateCamera();
+            CreateCanvas();
+        }
+
+        private void Update()
+        {
+            if (!_animateLoading)
+            {
+                return;
+            }
+
+            float phase = Mathf.Repeat(_logoAngle, 360f) / 360f;
+            float speed = Mathf.Lerp(45f, 230f, Mathf.Sin(phase * Mathf.PI) * Mathf.Sin(phase * Mathf.PI));
+            _logoAngle = Mathf.Repeat(_logoAngle - speed * Time.unscaledDeltaTime, 360f);
+            _logo.localRotation = Quaternion.Euler(0f, 0f, _logoAngle);
+
+            float time = Time.unscaledTime;
+            foreach (DecorationState decoration in _decorations)
+            {
+                float wave = Mathf.Sin(time * decoration.FloatSpeed + decoration.Phase);
+                decoration.Transform.anchoredPosition = decoration.BasePosition + Vector2.up * wave * decoration.FloatHeight;
+                decoration.Transform.localScale = decoration.BaseScale * (1f + wave * 0.035f);
+            }
+        }
+
+        public IEnumerator PlayGameStartRoutine()
+        {
+            yield return StopLogoRoutine(0.45f);
+
+            _blackOverlay.color = new Color(0.035f, 0.01f, 0.06f, 0f);
+            yield return FadeImageRoutine(_blackOverlay, 0f, 1f, 0.25f);
+            _loadingGroup.alpha = 0f;
+            _loadingCamera.enabled = false;
+            yield return FadeImageRoutine(_blackOverlay, 1f, 0f, 0.45f);
+
+            _gameStartGroup.alpha = 1f;
+            for (int i = 0; i < _gameCharacters.Length; i++)
+            {
+                StartCoroutine(PopCharacterRoutine(_gameCharacters[i], i));
+                yield return new WaitForSecondsRealtime(0.1f);
+            }
+
+            yield return new WaitForSecondsRealtime(0.65f);
+
+            Vector3 exitStartPosition = _gameStartGroup.transform.localPosition;
+            Vector3 dipPosition = exitStartPosition + Vector3.down * 22f;
+            Vector3 exitPosition = exitStartPosition + Vector3.up * 58f;
+            float elapsed = 0f;
+            const float dipDuration = 0.12f;
+            while (elapsed < dipDuration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                float t = SmoothStep(Mathf.Clamp01(elapsed / dipDuration));
+                _gameStartGroup.transform.localPosition = Vector3.Lerp(exitStartPosition, dipPosition, t);
+                _gameStartGroup.transform.localScale = new Vector3(
+                    Mathf.Lerp(1f, 1.04f, t),
+                    Mathf.Lerp(1f, 0.94f, t),
+                    1f);
+                yield return null;
+            }
+
+            elapsed = 0f;
+            const float fadeDuration = 0.32f;
+            while (elapsed < fadeDuration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                float t = Mathf.Clamp01(elapsed / fadeDuration);
+                float eased = 1f - Mathf.Pow(1f - t, 3f);
+                _gameStartGroup.alpha = 1f - SmoothStep(t);
+                _gameStartGroup.transform.localPosition = Vector3.Lerp(dipPosition, exitPosition, eased);
+                _gameStartGroup.transform.localScale = Vector3.Lerp(
+                    new Vector3(1.04f, 0.94f, 1f),
+                    Vector3.one,
+                    eased);
+                yield return null;
+            }
+
+            _gameStartGroup.alpha = 0f;
+            _gameStartGroup.transform.localPosition = exitStartPosition;
+            _gameStartGroup.transform.localScale = Vector3.one;
+        }
+
+        private IEnumerator StopLogoRoutine(float duration)
+        {
+            _animateLoading = false;
+            float startAngle = _logoAngle;
+            float targetAngle = Mathf.Floor(startAngle / 360f) * 360f - 360f;
+            float elapsed = 0f;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                _logo.localRotation = Quaternion.Euler(0f, 0f, Mathf.Lerp(startAngle, targetAngle, 1f - Mathf.Pow(1f - t, 3f)));
+                yield return null;
+            }
+
+            _logo.localRotation = Quaternion.identity;
+        }
+
+        private IEnumerator PopCharacterRoutine(RectTransform target, int index)
+        {
+            Vector2 finalPosition = target.anchoredPosition;
+            float finalRotation = target.localEulerAngles.z;
+            if (finalRotation > 180f)
+            {
+                finalRotation -= 360f;
+            }
+
+            Vector2 startPosition = finalPosition + Vector2.down * 85f;
+            float startRotation = finalRotation + Mathf.Lerp(-10f, 10f, index / 3f);
+            Image image = target.GetComponent<Image>();
+            Color color = image.color;
+            color.a = 0f;
+            image.color = color;
+            target.anchoredPosition = startPosition;
+            target.localScale = Vector3.zero;
+            target.localRotation = Quaternion.Euler(0f, 0f, startRotation);
+
+            float elapsed = 0f;
+            const float duration = 0.42f;
+            while (elapsed < duration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                float eased = EaseOutBack(t);
+                target.anchoredPosition = Vector2.LerpUnclamped(startPosition, finalPosition, eased);
+                target.localScale = Vector3.one * Mathf.LerpUnclamped(0f, 1f, eased);
+                target.localRotation = Quaternion.Euler(0f, 0f, Mathf.LerpUnclamped(startRotation, finalRotation, eased));
+                color.a = Mathf.Clamp01(t * 2.5f);
+                image.color = color;
+                yield return null;
+            }
+
+            target.anchoredPosition = finalPosition;
+            target.localScale = Vector3.one;
+            target.localRotation = Quaternion.Euler(0f, 0f, finalRotation);
+            color.a = 1f;
+            image.color = color;
+        }
+
+        private void CreateCamera()
+        {
+            GameObject cameraObject = new GameObject("LoadingCamera");
+            cameraObject.transform.SetParent(transform, false);
+            _loadingCamera = cameraObject.AddComponent<Camera>();
+            _loadingCamera.clearFlags = CameraClearFlags.SolidColor;
+            _loadingCamera.backgroundColor = new Color(0.035f, 0.01f, 0.06f, 1f);
+            _loadingCamera.cullingMask = 0;
+            _loadingCamera.depth = 100f;
+        }
+
+        private void CreateCanvas()
+        {
+            GameObject canvasObject = new GameObject("LoadingCanvas");
+            canvasObject.transform.SetParent(transform, false);
+            Canvas canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.sortingOrder = 32000;
+
+            CanvasScaler scaler = canvasObject.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920f, 1080f);
+            scaler.matchWidthOrHeight = 0.5f;
+            canvasObject.AddComponent<GraphicRaycaster>();
+
+            RectTransform loadingRoot = CreateRect("LoadingRoot", canvasObject.transform);
+            Stretch(loadingRoot);
+            _loadingGroup = loadingRoot.gameObject.AddComponent<CanvasGroup>();
+
+            Image background = CreateImage("Background", loadingRoot, null);
+            Stretch(background.rectTransform);
+            background.color = new Color(0.09f, 0.015f, 0.14f, 1f);
+
+            CreateDecorations(loadingRoot);
+
+            Image logoImage = CreateImage("LoadingLogo", loadingRoot, LoadSprite("UI_Title_Logo"));
+            _logo = logoImage.rectTransform;
+            _logo.anchorMin = _logo.anchorMax = new Vector2(0.5f, 0.52f);
+            _logo.sizeDelta = new Vector2(620f, 350f);
+            _logo.anchoredPosition = Vector2.zero;
+            logoImage.preserveAspect = true;
+
+            _blackOverlay = CreateImage("TransitionBlack", canvasObject.transform, null);
+            Stretch(_blackOverlay.rectTransform);
+            _blackOverlay.color = new Color(0.035f, 0.01f, 0.06f, 0f);
+
+            CreateGameStart(canvasObject.transform);
+        }
+
+        private void CreateDecorations(RectTransform parent)
+        {
+            CreateDecoration(parent, "UI_Title_Pumpkin", new Vector2(-760f, -330f), new Vector2(260f, 260f), -14f, 0.2f, 20f, 1.2f);
+            CreateDecoration(parent, "UI_Title_Apple", new Vector2(760f, -350f), new Vector2(300f, 300f), 13f, 1.1f, 24f, 1.05f);
+            CreateDecoration(parent, "UI_Title_Ghost", new Vector2(-770f, 340f), new Vector2(230f, 230f), 9f, 2.2f, 28f, 0.9f);
+            CreateDecoration(parent, "UI_Title_Candy", new Vector2(780f, 330f), new Vector2(220f, 220f), -10f, 3.1f, 22f, 1.25f);
+            CreateDecoration(parent, "UI_Title_Ice", new Vector2(-470f, -430f), new Vector2(180f, 180f), 16f, 4.2f, 18f, 1.4f);
+            CreateDecoration(parent, "UI_Title_Soul1", new Vector2(500f, 390f), new Vector2(150f, 150f), -8f, 5.1f, 34f, 0.8f);
+            CreateDecoration(parent, "UI_Title_Soul2", new Vector2(390f, -390f), new Vector2(130f, 130f), 7f, 0.8f, 30f, 1.0f);
+        }
+
+        private void CreateDecoration(
+            RectTransform parent,
+            string spriteName,
+            Vector2 position,
+            Vector2 size,
+            float rotation,
+            float phase,
+            float floatHeight,
+            float floatSpeed)
+        {
+            Image image = CreateImage(spriteName, parent, LoadSprite(spriteName));
+            RectTransform rect = image.rectTransform;
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = position;
+            rect.sizeDelta = size;
+            rect.localRotation = Quaternion.Euler(0f, 0f, rotation);
+            image.preserveAspect = true;
+            image.color = new Color(1f, 1f, 1f, 0.72f);
+
+            _decorations.Add(new DecorationState
+            {
+                Transform = rect,
+                BasePosition = position,
+                BaseScale = Vector3.one,
+                Phase = phase,
+                FloatHeight = floatHeight,
+                FloatSpeed = floatSpeed
+            });
+        }
+
+        private void CreateGameStart(Transform parent)
+        {
+            RectTransform root = CreateRect("GameStartRoot", parent);
+            root.anchorMin = root.anchorMax = new Vector2(0.5f, 0.72f);
+            root.sizeDelta = new Vector2(920f, 330f);
+            root.anchoredPosition = Vector2.zero;
+            _gameStartGroup = root.gameObject.AddComponent<CanvasGroup>();
+            _gameStartGroup.alpha = 0f;
+
+            string[] names = { "G", "A", "M", "E" };
+            string[] resources = { "UI_Clear_G", "UI_Clear_A", "UI_Clear_M", "UI_Clear_E" };
+            Vector2[] positions =
+            {
+                new Vector2(-300f, -35f),
+                new Vector2(-105f, 30f),
+                new Vector2(105f, 30f),
+                new Vector2(300f, -35f)
+            };
+            float[] rotations = { -12f, -4f, 4f, 12f };
+
+            _gameCharacters = new RectTransform[4];
+            for (int i = 0; i < _gameCharacters.Length; i++)
+            {
+                Image image = CreateImage(names[i], root, Resources.Load<Sprite>($"Textures/GAMECLEAR/char/{resources[i]}"));
+                RectTransform rect = image.rectTransform;
+                rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+                rect.sizeDelta = new Vector2(190f, 190f);
+                rect.anchoredPosition = positions[i];
+                rect.localRotation = Quaternion.Euler(0f, 0f, rotations[i]);
+                image.preserveAspect = true;
+                _gameCharacters[i] = rect;
+            }
+        }
+
+        private static Sprite LoadSprite(string name)
+        {
+            return Resources.Load<Sprite>(TextureRoot + name);
+        }
+
+        private static RectTransform CreateRect(string name, Transform parent)
+        {
+            GameObject gameObject = new GameObject(name, typeof(RectTransform));
+            gameObject.transform.SetParent(parent, false);
+            return (RectTransform)gameObject.transform;
+        }
+
+        private static Image CreateImage(string name, Transform parent, Sprite sprite)
+        {
+            RectTransform rect = CreateRect(name, parent);
+            Image image = rect.gameObject.AddComponent<Image>();
+            image.sprite = sprite;
+            image.raycastTarget = false;
+            return image;
+        }
+
+        private static void Stretch(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        private static IEnumerator FadeImageRoutine(Image image, float from, float to, float duration)
+        {
+            Color color = image.color;
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                color.a = Mathf.Lerp(from, to, SmoothStep(Mathf.Clamp01(elapsed / duration)));
+                image.color = color;
+                yield return null;
+            }
+
+            color.a = to;
+            image.color = color;
+        }
+
+        private static float SmoothStep(float t)
+        {
+            return t * t * (3f - 2f * t);
+        }
+
+        private static float EaseOutBack(float t)
+        {
+            const float c1 = 1.70158f;
+            const float c3 = c1 + 1f;
+            float value = t - 1f;
+            return 1f + c3 * value * value * value + c1 * value * value;
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/UI/Loading/LoadingView.cs.meta
+++ b/Assets/Scripts/Presentation/UI/Loading/LoadingView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2e5831d0a7f4c9db2648f3a015be796

--- a/Assets/Scripts/Presentation/UI/Title/TitleMenuController.cs
+++ b/Assets/Scripts/Presentation/UI/Title/TitleMenuController.cs
@@ -23,7 +23,7 @@ namespace Game.Presentation.UI.Title
         [SerializeField] private Button _startButton;
 
         [Header("--- 遷移先のシーン ---")]
-        [SerializeField] private string _bootSceneName = "Boot";
+        [SerializeField] private string _loadingSceneName = "Loading";
 
         public void OnEnable()
         {
@@ -35,8 +35,8 @@ namespace Game.Presentation.UI.Title
         /// </summary>
         public void OnClickNewGame()
         {
-            Debug.Log("New Game が押されたぜよ。シーン遷移: " + _bootSceneName);
-            SceneManager.LoadScene(_bootSceneName);
+            Debug.Log("New Game が押されたぜよ。シーン遷移: " + _loadingSceneName);
+            SceneManager.LoadScene(_loadingSceneName);
         }
 
         /// <summary>

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -9,6 +9,9 @@ EditorBuildSettings:
     path: Assets/Scenes/Title.unity
     guid: 1450679543521814a87f43f45bd6c1cb
   - enabled: 1
+    path: Assets/Scenes/Loading.unity
+    guid: c3a9f5d6e1724b4e9238d7a1f6c0b5e4
+  - enabled: 1
     path: Assets/Scenes/Boot.unity
     guid: 686ca123f808c3946ab11552a54e63a3
   - enabled: 1


### PR DESCRIPTION
## 概要
TitleからGameへ進む間にLoadingシーンを挟み、ゲーム素材の読み込みとシェーダーウォームアップが完了するまでロード演出を表示します。
通常開始とフルリセットを同じLoading経路へ統一し、ゲーム開始時にGAME文字の演出を追加します。

## 変更内容
- Loadingシーンを新設し、最低3秒のタイトル素材アニメーション中にBoot/Gameを読み込み、シェーダーをウォームアップ
- GAME文字を扇形に順次表示し、現在位置から一度沈んで上昇する終了演出を追加
- ゲーム進行開始を開始演出完了まで待機し、フルリセットもLoadingへ遷移するよう変更
- origin/master取り込み後に発生したボス攻撃イベントのコンパイルエラーを修正し、棘の接触位置と口の位置を攻撃座標として通知

## 確認項目 (セルフチェック)
### 💻 実装・品質
- [x] 命名規則: クラス・メソッド・フィールド名が既存規約に準拠している
- [ ] 整形: `dotnet format Assembly-CSharp.csproj --no-restore --verify-no-changes` は既存のリポジトリ全体の整形差分により失敗
- [x] メタ: 新規Unityアセット・スクリプトの `.meta` を含めている
- [x] 不要な変更: 依頼対象とmaster取り込み後のコンパイル修正に限定している

### 🏗️ 設計
- [x] 所有権: Loadingがロード進行、LoadingViewが表示演出を担当している
- [x] View責務: ロード進行とゲーム進行制御をViewへ持たせていない
- [x] 依存関係: Title/ResetからLoadingへ遷移し、LoadingからBoot/Gameを管理する方向に統一している

## 関連Issue
Closes #540

## その他
- `dotnet build Assembly-CSharp.csproj --no-restore`: 成功（0エラー、既存警告20件）
- `git diff --check`: 成功
- Unity PlayMode確認は、同一プロジェクトが別Unity Editorで開かれておりバッチ起動できなかったため未実施