### PR TITLE
[#570] ローグライクUIのフォントをMamelonへ変更

### DIFF
--- a/Assets/Prefab/Roguelike/Money.prefab
+++ b/Assets/Prefab/Roguelike/Money.prefab
@@ -69,8 +69,8 @@ MonoBehaviour:
 
 '
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Prefab/Roguelike/Upgrade.prefab
+++ b/Assets/Prefab/Roguelike/Upgrade.prefab
@@ -67,8 +67,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Arm size up!!
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -206,8 +206,8 @@ MonoBehaviour:
 
 '
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -343,8 +343,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 'Cost : 000'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -893,8 +893,8 @@ MonoBehaviour:
 
 '
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Prefab/Roguelike/UpgradeCard.prefab
+++ b/Assets/Prefab/Roguelike/UpgradeCard.prefab
@@ -67,8 +67,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -279,8 +279,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: New Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -652,8 +652,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Upgarde Name
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Prefab/Roguelike/UpgradeDetail.prefab
+++ b/Assets/Prefab/Roguelike/UpgradeDetail.prefab
@@ -303,8 +303,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: aaaaaaaaaaaaaaaaaaaaaaaaaaaa
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -440,8 +440,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 'Cost : 0000'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -577,8 +577,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 'Level : ??/??'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -714,8 +714,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Namenamename
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Scenes/Roguelike/Roguelike.unity
+++ b/Assets/Scenes/Roguelike/Roguelike.unity
@@ -984,8 +984,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Click - Space - UpButton
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
+  m_sharedMaterial: {fileID: -4556340863640074316, guid: c9ecfcc1218e802419fa2413548fc04a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []


### PR DESCRIPTION
## 概要
ローグライクUIのTextMeshProフォントをMamelonへ統一し、画面内の文字表現を揃えます。

## 変更内容
- ローグライク用Prefab内のTextMeshProUGUI 12箇所をMamelon-5-Hi-Regular SDFへ変更
- Roguelikeシーン直置きのTextMeshProUGUI 1箇所を同フォントへ変更
- 各テキストの共有マテリアルをMamelon付属マテリアルへ変更

## 確認項目 (セルフチェック)

### 💻 実装・品質
- [x] **命名規則**: 新規コードおよび命名変更なし
- [x] **整形**: C#変更なし。`git diff --cached --check` 成功
- [x] **メタファイル**: 新規ファイルなし
- [x] **不要な変更**: 対象5ファイルのフォント参照のみ

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: データ書き換えなし
- [x] **Viewの責務**: UIのフォント参照のみ変更
- [x] **依存関係**: 新規依存なし

## 関連Issue
Closes #570

## その他 (懸念点・共有事項)
- 対象範囲のMamelonフォント参照13件と付属マテリアル参照13件を確認済み
- 対象範囲の旧LiberationSans参照は0件
- Unity Editor上での画面表示・Console確認は、依頼者の指示により未実施
- Legacy Text、TMPのプロジェクト全体設定、Mamelonフォント本体は変更対象外
