### PR TITLE
YuureiとBatの落下時の向きを修正

### DIFF
--- a/Assets/Prefab/Enemy/BatBody.prefab
+++ b/Assets/Prefab/Enemy/BatBody.prefab
@@ -167,7 +167,7 @@ MonoBehaviour:
   _maxHitAnimationTime: 2
   _addHitAnimationTime: 1
   _dropDuration: 0.5
-  _dropRot: {x: 0, y: 90, z: -180}
+  _dropRot: {x: 0, y: 180, z: -180}
   _postFlipDelay: 0.25
   _useCartoonFeedback: 1
   _squashTarget: {fileID: 0}

--- a/Assets/Prefab/Enemy/GhostBody.prefab
+++ b/Assets/Prefab/Enemy/GhostBody.prefab
@@ -163,7 +163,7 @@ MonoBehaviour:
   _maxHitAnimationTime: 2
   _addHitAnimationTime: 1
   _dropDuration: 0.5
-  _dropRot: {x: 0, y: 90, z: -180}
+  _dropRot: {x: 0, y: 180, z: -180}
   _postFlipDelay: 0.25
   _useCartoonFeedback: 1
   _squashTarget: {fileID: 0}


### PR DESCRIPTION
## 概要
Yuurei と Bat が撃破後の落下時に横を向く不具合を修正します。

落下姿勢の Y 回転が 90 度に設定されていたことが原因だったため、背面を向く 180 度へ変更しました。

## 変更内容
- Yuurei の落下姿勢の Y 回転を 90 度から 180 度へ変更
- Bat の落下姿勢の Y 回転を 90 度から 180 度へ変更

## 確認項目 (セルフチェック)

### 💻 実装・品質
- [x] **命名規則**: コードおよび命名の変更なし
- [x] **整形**: Prefab 差分に対して `git diff --check` を実行
- [x] **メタファイル**: 新規ファイルなし
- [x] **不要な変更**: 対象の2つの Prefab 以外を除外

### 🏗️ 設計・アーキテクチャ
- [x] **所有権**: 既存の Prefab 設定値のみ変更
- [x] **Viewの責務**: データ処理の変更なし
- [x] **依存関係**: 依存関係の追加なし

## 関連Issue
Closes #573

## その他（懸念点・共有事項）
- Unity Editor での実機目視確認は未実施です。Yuurei と Bat を撃破し、後ろ向きに落下することを確認してください。
