### PR TITLE
Collectibleの壁際振動を修正

### DIFF
--- a/Assets/Scripts/Gameplay/Collectibles/Entities/CollectibleObject.cs
+++ b/Assets/Scripts/Gameplay/Collectibles/Entities/CollectibleObject.cs
@@ -91,19 +91,22 @@ namespace Game.Gameplay.Collectibles
             }
         }
 
-        private void OnCollisionEnter(Collision collision)
-        {
-            if (IsFieldWall(collision.transform)
-                && !IsEnemySideWall(collision.transform))
-            {
-                MoveInsideField(collision.collider);
-            }
-        }
-
         private void OnTriggerEnter(Collider other)
         {
-            if (IsFieldWall(other.transform)
-                && !IsEnemySideWall(other.transform))
+            if (!IsFieldWall(other.transform)
+                || IsEnemySideWall(other.transform))
+            {
+                return;
+            }
+
+            ResolveFieldWallBoundsIfNeeded();
+            if (_fieldWallRoot == null || !_hasFieldWallBounds)
+            {
+                return;
+            }
+
+            Vector3 localPosition = _fieldWallRoot.InverseTransformPoint(transform.position);
+            if (IsOutsideFieldBounds(localPosition))
             {
                 MoveInsideField(other);
             }
@@ -231,11 +234,15 @@ namespace Game.Gameplay.Collectibles
                     Mathf.Clamp(localPosition.z, _fieldWallLocalBounds.min.z, _fieldWallLocalBounds.max.z));
                 Vector3 clampedWorldPosition = _fieldWallRoot.TransformPoint(clampedPosition);
                 Vector3 inwardDirection = (fieldCenter - clampedWorldPosition).normalized;
-                SetPositionOnly(clampedWorldPosition + inwardDirection * insideClearance);
+                SetPositionAndRemoveOutwardVelocity(
+                    clampedWorldPosition + inwardDirection * insideClearance,
+                    outwardDirection);
                 return;
             }
 
-            SetPositionOnly(innerWallPoint - outwardDirection * insideClearance);
+            SetPositionAndRemoveOutwardVelocity(
+                innerWallPoint - outwardDirection * insideClearance,
+                outwardDirection);
         }
 
         private bool TryGetInnerWallPoint(
@@ -296,11 +303,22 @@ namespace Game.Gameplay.Collectibles
                 + Mathf.Abs(direction.z) * extents.z;
         }
 
-        private void SetPositionOnly(Vector3 position)
+        private void SetPositionAndRemoveOutwardVelocity(
+            Vector3 position,
+            Vector3 outwardDirection)
         {
             if (_rigidbody != null)
             {
                 _rigidbody.position = position;
+
+                float outwardSpeed = Vector3.Dot(
+                    _rigidbody.linearVelocity,
+                    outwardDirection);
+                if (outwardSpeed > 0f)
+                {
+                    _rigidbody.linearVelocity -= outwardDirection * outwardSpeed;
+                }
+
                 return;
             }
 


### PR DESCRIPTION
## 概要
`Collectible(Clone)`がフィールド端の壁で押し戻しと再衝突を繰り返し、振動する問題を修正します。

## 変更内容
- Solid壁との通常衝突時に位置を強制補正する処理を削除
- Trigger経由では実際にフィールド範囲外の場合だけ復旧
- 範囲外から復旧する際、壁外方向の速度成分を除去

## 原因
フィールド重力が壁方向へ加速し続ける状況で、壁衝突のたびに位置だけを内側へ移動していました。壁方向の速度が残るため、補正後に再衝突する処理が繰り返されていました。

## 影響
通常の壁接触はPhysXが解決し、すり抜け時だけ既存のフィールド内復旧処理が働きます。重力、Collider、グミのPhysics Materialは変更していません。

## 確認項目
- [x] `dotnet build Assembly-CSharp.csproj --no-restore --nologo`
- [x] コンパイルエラー0件
- [x] `git diff --check`
- [x] PR差分が`CollectibleObject.cs`のみであることを確認
- [ ] Unity Play Modeで壁際、角、高速衝突、グミの挙動を確認

Closes #594