### PR TITLE
fix: ボスのダメージを特定のオブジェクトでの攻撃に変更

### DIFF
--- a/Assets/CreatorKousien/Content/Features/Enemies/Bosses/Prefabs/BalanceGimmick/PFB_BalanceWeakness.prefab
+++ b/Assets/CreatorKousien/Content/Features/Enemies/Bosses/Prefabs/BalanceGimmick/PFB_BalanceWeakness.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2876942215081343606}
   - component: {fileID: 2934729907795979115}
   - component: {fileID: 7136180240002397430}
+  - component: {fileID: 3248323932791637932}
   m_Layer: 0
   m_Name: PFB_BalanceWeakness
   m_TagString: Untagged
@@ -117,6 +118,26 @@ MonoBehaviour:
   _spawnLayer: CollectibleSpawning
   _normalLayer: Collectible
   _passThroughDuration: 0.4
+--- !u!114 &3248323932791637932
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62624467482769536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7be90c084865f84caeef8cef9ab0cff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BalanceCatapultBall
+  _rigidbody: {fileID: 2934729907795979115}
+  _battleFlowController: {fileID: 0}
+  _baseDamage: 5
+  _speedDamageMultiplier: 2
+  _minLaunchSpeed: 0
+  _bossLayer:
+    serializedVersion: 2
+    m_Bits: 1
 --- !u!1001 &6222394822971739052
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/CreatorKousien/Content/Features/Enemies/Bosses/Prefabs/PFB_Balance_Boss.prefab
+++ b/Assets/CreatorKousien/Content/Features/Enemies/Bosses/Prefabs/PFB_Balance_Boss.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &589366888828555011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7742797030565827278}
+  m_Layer: 0
+  m_Name: SpawnAnchorRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7742797030565827278
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589366888828555011}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.15, y: 0.25, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5753569247408130232}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1717210168770136121
 GameObject:
   m_ObjectHideFlags: 0
@@ -307,6 +338,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4389981377617131478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3852923020680528231}
+  m_Layer: 0
+  m_Name: SpawnAnchorLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3852923020680528231
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4389981377617131478}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.15, y: 0.35, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5753569247408130232}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4753058131186875055
 GameObject:
   m_ObjectHideFlags: 0
@@ -898,6 +960,7 @@ GameObject:
   - component: {fileID: 7013348292912107979}
   - component: {fileID: 4916870854334847704}
   - component: {fileID: 1830859312870177099}
+  - component: {fileID: 2705253161281346588}
   m_Layer: 0
   m_Name: PFB_Balance_Boss
   m_TagString: Untagged
@@ -992,7 +1055,7 @@ MonoBehaviour:
   _currentHP: 0
   _triggerVictoryOnZeroHp: 1
   _timeLimit: 0
-  _useDownSystem: 1
+  _useDownSystem: 0
   _downDuration: 5
   _downAnimTrigger: Down
   _recoverAnimTrigger: Recover
@@ -1002,9 +1065,9 @@ MonoBehaviour:
   _bossAnimator: {fileID: 0}
   _socketBindings:
   - socket: 2
-    transform: {fileID: 7808416660120670462}
+    transform: {fileID: 3852923020680528231}
   - socket: 3
-    transform: {fileID: 8229413870754703134}
+    transform: {fileID: 7742797030565827278}
   _introSequenceController: {fileID: 7857437713337581539}
   _introSequenceData: {fileID: 11400000, guid: 9dc04bc9e6f3e5c46a896e2b08231559, type: 2}
   _gimmickSlots:
@@ -1057,6 +1120,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Enemy.Boss.BossDownPresentationController
   _animationController: {fileID: 5299479073697936780}
   _effectAnchor: {fileID: 6479304743537242019}
+--- !u!114 &2705253161281346588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8983832462583435428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4038ed9c822d0204ea010841cf1565ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BalanceCatapultController
+  _scale: {fileID: 1387062995938564052}
+  _launchImpulsePerMass: 3
+  _minLaunchImpulse: 8
 --- !u!1001 &5657809737843735654
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1170,6 +1248,12 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: -9125318389815544610, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8229413870754703134}
+    - targetCorrespondingSourceObject: {fileID: -9125318389815544610, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3852923020680528231}
+    - targetCorrespondingSourceObject: {fileID: -9125318389815544610, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7742797030565827278}
     - targetCorrespondingSourceObject: {fileID: -5861409178561632961, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2456045077046570784}
@@ -1213,6 +1297,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: -4819223349682164798, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
       insertIndex: -1
       addedObject: {fileID: 7596420243939097881}
+    - targetCorrespondingSourceObject: {fileID: -4819223349682164798, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2174047390327891194}
     - targetCorrespondingSourceObject: {fileID: 7753705370032899036, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8707206971518386500}
@@ -1285,7 +1372,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0cca841aa5565346a7cd45d6ccc6628, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::BossHitReceiver
-  _flowController: {fileID: 0}
+  _flowController: {fileID: 7013348292912107979}
   _minimumHitSpeed: 0.75
   _damageMultiplier: 1.5
   _despawnItemOnHit: 1
@@ -1302,10 +1389,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Enemy.Boss.BossTriggeredWeakPoint
   _flowController: {fileID: 7013348292912107979}
-  _hitCollider: {fileID: 0}
+  _hitCollider: {fileID: 8126121512178337333}
   _restrictRequierType: 1
   _requiredType: 6
-  _startExposed: 0
+  _startExposed: 1
   _triggerDownOnHit: 1
   _hitCooldown: 0.2
 --- !u!135 &8126121512178337333
@@ -1596,6 +1683,7 @@ MonoBehaviour:
   _tiltSensitivity: 5
   _stiffness: 12
   _damping: 2.5
+  _suddenWeightThreshold: 0
   _maxPanTiltAngle: 40
 --- !u!114 &8757943479672085338
 MonoBehaviour:
@@ -1604,7 +1692,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8330038765687330724}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a0cca841aa5565346a7cd45d6ccc6628, type: 3}
   m_Name: 
@@ -1636,6 +1724,25 @@ CapsuleCollider:
   m_Height: 0.1763525
   m_Direction: 1
   m_Center: {x: -0.00020134076, y: 0.086835995, z: -0.000000007450581}
+--- !u!114 &2174047390327891194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8330038765687330724}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8fced52e1fb1a4468d33bd631857494, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Enemy.Boss.BossTriggeredWeakPoint
+  _flowController: {fileID: 7013348292912107979}
+  _hitCollider: {fileID: 7596420243939097881}
+  _restrictRequierType: 1
+  _requiredType: 6
+  _startExposed: 0
+  _triggerDownOnHit: 0
+  _hitCooldown: 0.2
 --- !u!137 &8341517052891440528 stripped
 SkinnedMeshRenderer:
   m_CorrespondingSourceObject: {fileID: 4415663344214530550, guid: 2674086d7151e7243a65a5b9a6c0e0bd, type: 3}

--- a/Assets/CreatorKousien/Content/Features/Enemies/Data/Enemies_SO_BalanceBoss_IntroSequence.asset
+++ b/Assets/CreatorKousien/Content/Features/Enemies/Data/Enemies_SO_BalanceBoss_IntroSequence.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   _leftStartEulerAngles: {x: 0, y: 0, z: 0}
   _rightStartLocalPosition: {x: 0, y: 0, z: 0}
   _rightStartEulerAngles: {x: 0, y: 0, z: 0}
-  _battleLocalPosition: {x: 0, y: -8, z: -7}
+  _battleLocalPosition: {x: 0, y: -13, z: -7}
   _battleEulerAngles: {x: 0, y: 180, z: 0}
   _moveDuration: 1.2
   _moveCurve:

--- a/Assets/CreatorKousien/Content/Features/Enemies/Data/Enemies_SO_BalanceGimmick_Bring.asset
+++ b/Assets/CreatorKousien/Content/Features/Enemies/Data/Enemies_SO_BalanceGimmick_Bring.asset
@@ -20,5 +20,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: fbb2cc8966f32664a8448550983be955, type: 2}
   - {fileID: 11400000, guid: 9998b8dbc0c5ce04e9654396168d57bf, type: 2}
   - {fileID: 11400000, guid: 0bd912b3ef729924d81e248d6df2ca12, type: 2}
-  _weaknessObjectChance: 0.3
+  _weaknessObjectChance: 1
   _SummonMonster: {fileID: 6342730725154082049, guid: b69e6f96a0b7df14ea6d1426833735b0, type: 3}

--- a/Assets/CreatorKousien/Content/Features/Enemies/Data/SO_Boss_BalanceGimmick.asset
+++ b/Assets/CreatorKousien/Content/Features/Enemies/Data/SO_Boss_BalanceGimmick.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   ExecutionType: 0
   animTriggerName: BalamceAction
   isRandomInterval: 0
-  minInterval: 5
+  minInterval: 2
   maxInterval: 10
   triggerTimes: []
   waitForCompletion: 1

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceBarrierAttackObject.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceBarrierAttackObject.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using Game.Core.Events;
-
+using Game.Gameplay.Enemy.Boss;
 
 public class BalanceBarrierAttackObject : MonoBehaviour, IBossTrayItem
 {

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultBall.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultBall.cs
@@ -1,0 +1,36 @@
+using Game.Gameplay.Enemy.Boss;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class BalanceCatapultBall : MonoBehaviour
+{
+    [SerializeField] private Rigidbody _rigidbody;
+    [SerializeField] private BossBattleFlowController _battleFlowController;
+    [SerializeField] private float _baseDamage = 5.0f;
+    [SerializeField] private float _speedDamageMultiplier = 2.0f;
+    [Tooltip("これ未満の速度での接触はダメージ無し")]
+    [SerializeField] private float _minLaunchSpeed = 3.0f;
+    [SerializeField] private LayerMask _bossLayer;
+
+    private void Awake()
+    {
+        if(_rigidbody == null )_rigidbody = GetComponent<Rigidbody>();
+    }
+
+    public void Initialize(BossContext context)
+    {
+        _battleFlowController = context.Controller;
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (((1 << collision.gameObject.layer) & _bossLayer) == 0) return;
+        if (!collision.transform.GetComponentInParent<BossHitReceiver>()) return;
+
+        float speed = _rigidbody.linearVelocity.magnitude;
+        if (speed < _minLaunchSpeed) return;
+
+        float damage = _baseDamage + speed * _speedDamageMultiplier;
+        _battleFlowController.TakeDamage(damage);
+    }
+}

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultBall.cs.meta
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultBall.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7be90c084865f84caeef8cef9ab0cff

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultController.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultController.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+public class BalanceCatapultController : MonoBehaviour
+{
+    [SerializeField] private RealisticBalanceScale _scale;
+    [SerializeField] private float _launchImpulsePerMass = 3.0f;
+    [SerializeField] private float _minLaunchImpulse = 8.0f;
+
+    private void OnEnable() => _scale.OnWeightSuddenlyAdded += HandleSuddenWeight;
+    private void OnDisable() => _scale.OnWeightSuddenlyAdded -= HandleSuddenWeight;
+
+    private void HandleSuddenWeight(bool isLeftLoaded,float addedMass)
+    {
+        var launchTargets = _scale.GetWeightOnSide(!isLeftLoaded);
+        float impulse = Mathf.Max(_minLaunchImpulse, addedMass * _launchImpulsePerMass);
+
+        foreach (var rb in launchTargets)
+        {
+            if(rb == null) continue;
+            rb.AddForce(Vector3.up * impulse, ForceMode.Impulse);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultController.cs.meta
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4038ed9c822d0204ea010841cf1565ac

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceGimmickJudge.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceGimmickJudge.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Game.Gameplay.Enemy.Boss;
 
 [CreateAssetMenu(fileName = "Gimmick_Judge", menuName = "Boss/Gimmicks/Balance/")]
 public class BalanceGimmickJudge : BossGimmickSO

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceGimmick_BalanceSlam.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceGimmick_BalanceSlam.cs
@@ -1,7 +1,6 @@
 using System;
 using UnityEngine;
 using Game.Core.Events;
-using Game.Core.DefenceLine;
 using Game.Gameplay.Collectibles;
 
 namespace Game.Gameplay.Enemy.Boss
@@ -24,6 +23,15 @@ namespace Game.Gameplay.Enemy.Boss
         [SerializeField] private int _bonusRewardCount = 4;
         [SerializeField] private Vector3 _rewardSpawnOffset = new Vector3(0f, 1f, 0f);
 
+        [Header("==== 自動傾斜(抑制対象) =====")]
+        [SerializeField] private RealisticBalanceScale _scale;
+        [SerializeField] private float _biasStrength = 8.0f;
+
+        [Header("==== 警告(演出フック) ====")]
+        [Tooltip("この割合を超えたら警告イベントを一回だけ発行")]
+        [SerializeField, Range(0.0f, 1.0f)] private float _warningThreshold = 0.7f;
+        private bool _hasWarned;
+
         private BossBalanceBeamController _beam;
         private CollectibleSpawner _collectibleSpawner;
 
@@ -39,6 +47,7 @@ namespace Game.Gameplay.Enemy.Boss
         {
             base.Initialize(context);
             _beam = context.Transform.GetComponentInChildren<BossBalanceBeamController>();
+            _scale = context.Transform.GetComponentInChildren<RealisticBalanceScale>();
             _collectibleSpawner = UnityEngine.Object.FindFirstObjectByType<CollectibleSpawner>();
         }
 
@@ -47,7 +56,10 @@ namespace Game.Gameplay.Enemy.Boss
             _elapsed = 0f;
             _safeTime = 0f;
             _hasDamagedThisRaise = false;
+            _hasWarned = false;
             _isComplete = false;
+
+            _scale.SetExternalBias(_dangerSide == TraySide.Left ? -_biasStrength : _biasStrength);
 
             if (_beam != null)
             {
@@ -60,13 +72,18 @@ namespace Game.Gameplay.Enemy.Boss
         {
             _elapsed += dt;
 
-            var side = _beam.FindSideOf<BalanceBarrierAttackObject>();
-            if(side.HasValue) _dangerSide = side.Value;
+            float tilt = _beam != null ? _beam.GetTiltRatio(_dangerSide) : 0.0f;
 
-            // 危険側が振り切られていない時間だけ「耐えた時間」として積算
-            if (_beam == null || _beam.GetTiltRatio(_dangerSide) < 1.0f)
+            if (tilt < 1.0f) _safeTime += dt;
+
+            if (!_hasWarned && tilt >= _warningThreshold)
             {
-                _safeTime += dt;
+                _hasWarned = true;
+                EventBus.Publish(new BalanceSlamWarningEvent((int)_dangerSide));
+            }
+            else if (_hasWarned && tilt < _warningThreshold - 0.1f)
+            {
+                _hasWarned = false;
             }
 
             if (_elapsed >= _challengeDuration)
@@ -95,6 +112,7 @@ namespace Game.Gameplay.Enemy.Boss
 
         private void Complete()
         {
+            _scale.SetExternalBias(0.0f);
             Unsubscribe();
 
             float safeRatio = _challengeDuration > 0f ? Mathf.Clamp01(_safeTime / _challengeDuration) : 0f;
@@ -117,6 +135,7 @@ namespace Game.Gameplay.Enemy.Boss
 
         public override void Cancel()
         {
+            _scale.SetExternalBias(0.0f);
             Unsubscribe();
         }
 

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceWeaknessObject.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceWeaknessObject.cs
@@ -16,6 +16,11 @@ public class BalanceWeaknessObject : MonoBehaviour, IBossHittable, IBossTrayItem
         if (_hitCollider != null) _hitCollider.enabled = false;
     }
 
+    public void Initialize(BossBattleFlowController flowController )
+    {
+        _flowController = flowController;
+    }
+
     public void OnTrayRaised()
     {
         _isExposed = true;

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/Balance_BringMonster.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/Balance_BringMonster.cs
@@ -9,7 +9,8 @@ public class Balance_BringMonster : MonoBehaviour
     
     private bool _isSpawned = false;
     public bool IsSpawned => _isSpawned;
-    private float _speed = 3.0f;
+    [SerializeField]
+    private float _speed = 8.0f;
 
     [SerializeField] private Animator _animator;
 

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BossBalanceBeamController.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BossBalanceBeamController.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
+
+namespace Game.Gameplay.Enemy.Boss
+{
 public enum TraySide { Left, Right, Level }
 
 public interface IBossTrayItem
@@ -95,4 +98,5 @@ public sealed class BossBalanceBeamController : MonoBehaviour
             OnTrayFullyLowered?.Invoke(side);
         }
     }
+}
 }

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/RealisticBalanceScale.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/RealisticBalanceScale.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data;
 using UnityEngine;
 
 public class RealisticBalanceScale : MonoBehaviour
@@ -10,11 +11,23 @@ public class RealisticBalanceScale : MonoBehaviour
     [SerializeField] private Transform _leftPanTransform;
     [SerializeField] private Transform _rightPanTransform;
 
-    [Header("==== 天秤んの物理パラメータ =====")]
+    [Header("==== 天秤の物理パラメータ =====")]
     [SerializeField] private float _maxTiltAngle = 30.0f;
     [SerializeField] private float _tiltSensitivity = 5.0f;
     [SerializeField] private float _stiffness = 12.0f;
     [SerializeField] private float _damping = 2.5f;
+
+    [Header("==== カタパルト検知 ====")]
+    [Tooltip("１階の登録でこの質量以上が一気に増えたら急速加重とみなす")]
+    [SerializeField] private float _suddenWeightThreshold = 5.0f;
+
+    // 外部バイアス　ギミックから傾きを強制
+    private bool _isFrozen;
+    public void SetFrozen(bool frozen) => _isFrozen = frozen;
+
+    private float _externalBias;
+    public void SetExternalBias(float bias) => _externalBias = bias;
+    
 
     [Header("==== 皿の傾き(滑り落ち)設定 ====")]
     [SerializeField] private float _maxPanTiltAngle = 40.0f;
@@ -22,19 +35,26 @@ public class RealisticBalanceScale : MonoBehaviour
     private float _currentAngle = 0.0f;
     private float _angularVelocity = 0.0f;
 
-    private readonly HashSet<Rigidbody> _leftPanWights = new HashSet<Rigidbody>();
-    private readonly HashSet<Rigidbody> _rightPanWights = new HashSet<Rigidbody>();
+    private readonly HashSet<Rigidbody> _leftPanWeights = new HashSet<Rigidbody>();
+    private readonly HashSet<Rigidbody> _rightPanWeights = new HashSet<Rigidbody>();
 
     public float CurrentAngle => _currentAngle;
     public Transform LeftPanTransform => _leftPanTransform;
     public Transform RightPanTransform => _rightPanTransform;
 
+    public event System.Action<bool, float> OnWeightSuddenlyAdded;
+
+    public IReadOnlyCollection<Rigidbody> GetWeightOnSide(bool isLeft) =>
+        isLeft ? _leftPanWeights : _rightPanWeights;
+
     private void FixedUpdate()
     {
-        float leftMass = CalculateTotalMass(_leftPanWights);
-        float rightMass = CalculateTotalMass(_rightPanWights);
+        if (_isFrozen) return;
 
-        float massDifference = rightMass - leftMass;
+        float leftMass = CalculateTotalMass(_leftPanWeights);
+        float rightMass = CalculateTotalMass(_rightPanWeights);
+
+        float massDifference = (rightMass - leftMass) + _externalBias;
         float targetAngle = Mathf.Clamp(massDifference * _tiltSensitivity, -_maxTiltAngle, _maxTiltAngle);
 
         float force = (targetAngle - _currentAngle) * _stiffness;
@@ -84,15 +104,23 @@ public class RealisticBalanceScale : MonoBehaviour
     public void RegisterWeight(bool isLeft,Rigidbody rb)
     {
         if (rb == null) return;
-        if (isLeft) _leftPanWights.Add(rb);
-        else _rightPanWights.Add(rb);
+
+        var set = isLeft ? _leftPanWeights : _rightPanWeights;
+        if (set.Contains(rb)) return;
+
+        set.Add(rb);
+        
+        if(rb.mass >= _suddenWeightThreshold)
+        {
+            OnWeightSuddenlyAdded?.Invoke(isLeft, rb.mass);
+        }
     }
 
     public void UnregisterWeight(bool isLeft, Rigidbody rb)
     {
         if (rb == null) return;
-        if (isLeft) _leftPanWights.Remove(rb);
-        else _rightPanWights.Remove(rb);
+        if (isLeft) _leftPanWeights.Remove(rb);
+        else _rightPanWeights.Remove(rb);
     }
 
 }

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Data/BalanceGimmick_BringWeight.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Data/BalanceGimmick_BringWeight.cs
@@ -1,8 +1,9 @@
 using Game.Data.Collectibles;
 using Game.Gameplay.Collectibles;
 using System.Collections.Generic;
-using TMPro;
 using UnityEngine;
+using Game.Gameplay.Enemy.Boss;
+using UnityEditor.Rendering.LookDev;
 
 [CreateAssetMenu(fileName = "BalanceGimmick_BringWeight", menuName = "Boss/Gimmick/Balance_BringWeight")]
 public class BalanceGimmick_BringWeight : BossGimmickSO
@@ -104,10 +105,19 @@ public class BalanceGimmick_BringWeight : BossGimmickSO
         var prefab = _weaknessPrefabs[UnityEngine.Random.Range(0, _weaknessPrefabs.Count)];
         var instance = Instantiate(prefab, position, rotation);
 
+        if(instance.TryGetComponent(out BalanceWeaknessObject weakObj))
+        {
+            weakObj.Initialize(Context.Controller);
+        }
+        if(instance.TryGetComponent(out BalanceCatapultBall catapultObj))
+        {
+            catapultObj.Initialize(Context);
+        }
+
         if (instance.TryGetComponent(out IBossTrayItem item))
         {
             _beamController.RegisterItem(_targetSide, item);
-        }
+        }        
     }
 
     private void SpawnCollectible(Vector3 position)

--- a/Assets/Scripts/Presentation/ScreenFeedback/BalanceSlamWarningPresenter.cs
+++ b/Assets/Scripts/Presentation/ScreenFeedback/BalanceSlamWarningPresenter.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using Game.Core.Events;
+
+namespace Game.Presentation.ScreenFeedback
+{
+    public sealed class BalanceSlamWarningPresenter : MonoBehaviour
+    {
+        private void OnEnable() => EventBus.Subscribe<BalanceSlamWarningEvent>(HandleWarning);
+        private void OnDisable() => EventBus.Unsubscribe<BalanceSlamWarningEvent>(HandleWarning);
+
+        private void HandleWarning(BalanceSlamWarningEvent ev)
+        {
+            EventBus.Publish(new CameraShakeRequestedEvent());
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/ScreenFeedback/BalanceSlamWarningPresenter.cs.meta
+++ b/Assets/Scripts/Presentation/ScreenFeedback/BalanceSlamWarningPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0118341177d475546b4f488c05a2cf0c

--- a/Assets/_Project/Runtime/Events/GameEvents.cs
+++ b/Assets/_Project/Runtime/Events/GameEvents.cs
@@ -574,4 +574,11 @@ namespace Game.Core.Events
     public struct BossIntroWarningEndedEvent
     { }
 
+    public readonly struct BalanceSlamWarningEvent
+    {
+        public readonly int DangerSide;
+        public BalanceSlamWarningEvent(int dangerSide) => DangerSide = dangerSide;
+    }
+    
+
 }


### PR DESCRIPTION
## 概要
ボスを特定のオブジェクトでダメージが入るように
打ち上げることでダメージアップするはず

## 変更内容
- 
- 

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [ ] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [ ] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [ ] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #番号

## その他 (懸念点・共有事項)

