### PR TITLE
webhookで指定のジョブの通知を受け取れるように変更

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -35,6 +35,48 @@ pipeline {
     }
 
     post {
+        success {
+            withCredentials([
+                string(
+                    credentialsId: 'discord-webhook',
+                    variable: 'DISCORD_WEBHOOK_URL'
+                )
+            ]) {
+                powershell '''
+                $body = @{
+                    content = "CreatorKousien Jenkins Build SUCCESS`nBuild #$env:BUILD_NUMBER`n$env:BUILD_URL"
+                } | ConvertTo-Json
+
+                Invoke-RestMethod `
+                    -Uri "$env:DISCORD_WEBHOOK_URL" `
+                    -Method Post `
+                    -ContentType "application/json" `
+                    -Body $body
+                '''
+            }
+        }
+
+        failure {
+            withCredentials([
+                string(
+                    credentialsId: 'discord-webhook',
+                    variable: 'DISCORD_WEBHOOK_URL'
+                )
+            ]) {
+                powershell '''
+                $body = @{
+                    content = "CreatorKousien Jenkins Build FAILED`nBuild #$env:BUILD_NUMBER`n$env:BUILD_URL"
+                } | ConvertTo-Json
+
+                Invoke-RestMethod `
+                    -Uri "$env:DISCORD_WEBHOOK_URL" `
+                    -Method Post `
+                    -ContentType "application/json" `
+                    -Body $body
+                '''
+            }
+        }
+
         always {
             archiveArtifacts artifacts: 'unity-build.log',
                              allowEmptyArchive: true


### PR DESCRIPTION
## 概要
*Discordで通知を受け取れるようにJenkinsfileを変更*

## 変更内容
- 特定のジョブの通知を受け取れるようにJenkinsfileを変更し、ました。
- トリガーがかなり限定的なのでFAILUREが多いかもしれない

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [ ] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [ ] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [ ] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

