### PR TITLE
fix : エフェクトのあった血が消えていたので修正、次消えても大丈夫なようにNullCheck入れました

### DIFF
--- a/Assets/CreatorKousien/Content/Features/Enemies/Data/Enemies_SO_CatapultGimmick.asset
+++ b/Assets/CreatorKousien/Content/Features/Enemies/Data/Enemies_SO_CatapultGimmick.asset
@@ -13,17 +13,25 @@ MonoBehaviour:
   m_Name: Enemies_SO_CatapultGimmick
   m_EditorClassIdentifier: Assembly-CSharp::Game.Gameplay.Enemy.Boss.BalanceCatapultGimmick
   _attackSide: 1
-  _biasStrength: 6
   _defenderDefinitions:
   - {fileID: 11400000, guid: 4cb55c9a8a363064c9bf094f77b06186, type: 2}
   - {fileID: 11400000, guid: 6d52fc24390483f40a4e16bb1fab2c90, type: 2}
   _defenderSpawnInterval: 3
   _defenderHpRate: 1
+  _defenderMinDistance: 2
+  _spawnerVfxPrefab: {fileID: 8518442979827585415, guid: f4bd3474d6bca7b4eb50d1a7e1fae100, type: 3}
   _ironBallDelay: 8
-  _reverseThreshold: 0.9
+  _ballCount: 4
   _ironBallPrefab: {fileID: 62624467482769536, guid: 72013cb1df2e4c8408b3c69fd8628c2a, type: 3}
+  _settleDuration: 1
+  _reverseThreshold: 0.9
   _ballBossDamage: 50
   _ballBarrierDamage: 25
   _beamAnimator: {fileID: 0}
   _shakeOffTriggerName: ShakeOff
   _shakeOffDuration: 0.8
+  _bossAnimator: {fileID: 0}
+  _barrierAttackTriggerName: BarrierSlam
+  _fullyRaisedBarrierDamage: 15
+  _barrierAttackVfxPrefab: {fileID: 0}
+  _vfxLifetime: 2

--- a/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultGimmick.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Boss/Balance/BalanceCatapultGimmick.cs
@@ -153,8 +153,11 @@ namespace Game.Gameplay.Enemy.Boss
         {
             if(_phaseTimer >= _shakeOffDuration)
             {
-                _currentSpawnerVfx = Instantiate(_spawnerVfxPrefab, Context.GetSocket(
-                    _attackSide == TraySide.Left ? BossSocket.LeftHand : BossSocket.RightHand).transform);
+                if(_spawnerVfxPrefab != null)
+                {
+                    _currentSpawnerVfx = Instantiate(_spawnerVfxPrefab, Context.GetSocket(
+                        _attackSide == TraySide.Left ? BossSocket.LeftHand : BossSocket.RightHand).transform);
+                }
                 ChangePhase(Phase.Prep);
             }
         }


### PR DESCRIPTION
## 概要
プレハブのアタッチが消えてエラーで止まっていたのでNullCheckを入れて対策
＆設定しなおし

## 変更内容
- 
- 

## 確認項目 (セルフチェック)
設計・品質を守るために、以下の項目を確認してください。

### 💻 実装・品質
- [ ] **命名規則**: `STYLE_GUIDE.md` に従った命名（Suffix等）になっているか
- [ ] **整形**: `dotnet format` が通り、`.editorconfig` に従っているか
- [ ] **メタファイル**: 新規ファイルに `.meta` ファイルが含まれているか
- [ ] **不要な変更**: デバッグログや不要な `using` が残っていないか

### 🏗️ 設計・アーキテクチャ
- [ ] **所有権**: データを書き換えているのは「所有システム」のみか
- [ ] **Viewの責務**: View クラスからデータの直接書き換えを行っていないか
- [ ] **依存関係**: 依存先を増やす前に `GameMediator` を検討したか

## 関連Issue
Closes #

## その他 (懸念点・共有事項)

